### PR TITLE
RISDEV-5845

### DIFF
--- a/otc-css-cluster/main.tf
+++ b/otc-css-cluster/main.tf
@@ -20,7 +20,7 @@ resource "opentelekomcloud_css_cluster_v1" "this" {
     }
     volume {
       volume_type = var.volume_type
-      size        = 40
+      size        = var.volume_size
     }
     availability_zone = var.availability_zone
   }

--- a/otc-css-cluster/variables.tf
+++ b/otc-css-cluster/variables.tf
@@ -67,3 +67,9 @@ variable "admin_pass" {
   description = "Password of the cluster user admin"
   type = string
 }
+
+variable "volume_size" {
+  description = "Specifies the volume size."
+  default     = 40
+  type = number
+}

--- a/otc-css-cluster/variables.tf
+++ b/otc-css-cluster/variables.tf
@@ -70,6 +70,6 @@ variable "admin_pass" {
 
 variable "volume_size" {
   description = "Specifies the volume size."
-  default     = 40
+  default = 40
   type = number
 }


### PR DESCRIPTION
Deploy prototype portal (public)
*Add volume_size to let users of the module specify the size of the volumes used by the nodes in the cluster.