### PR TITLE
Pass through user_domain_names

### DIFF
--- a/otc-obs-static-website-bucket/main.tf
+++ b/otc-obs-static-website-bucket/main.tf
@@ -2,6 +2,8 @@ resource "opentelekomcloud_obs_bucket" "this" {
   bucket = var.bucket_name
   acl    = "public-read"
   versioning = var.versioning_enabled
+  user_domain_names = var.user_domain_names
+
   website {
     index_document = "index.html"
     error_document = "404.html"

--- a/otc-obs-static-website-bucket/variables.tf
+++ b/otc-obs-static-website-bucket/variables.tf
@@ -12,3 +12,9 @@ variable "versioning_enabled" {
   type        = bool
   default     = false
 }
+
+variable "user_domain_names" {
+  description = "Specifies the user domain names"
+  type        = set(string)
+  default     = []
+}


### PR DESCRIPTION
This PR enables support for https://registry.terraform.io/providers/opentelekomcloud/opentelekomcloud/latest/docs/resources/obs_bucket#user_domain_names-1