### PR TITLE
Include deploying repository name in deploy key name

### DIFF
--- a/deploy-key/main.tf
+++ b/deploy-key/main.tf
@@ -11,7 +11,7 @@ resource "github_actions_environment_secret" "private_deploy_key" {
 
 resource "github_repository_deploy_key" "public_deploy_key" {
   repository = var.infra_repository
-  title      = var.environment
+  title      = "${var.deploying_repository}: ${var.environment}"
   key        = tls_private_key.deploy_key.public_key_openssh
   read_only  = "false"
 }


### PR DESCRIPTION
We (ris-norms) deploy to the same infra repo form two repos. This enables us to see which deploy key is used by which repo.