### PR TITLE
fix(otc-rdc-database): add "period" parameter for backup

### DIFF
--- a/otc-rds-database/main.tf
+++ b/otc-rds-database/main.tf
@@ -47,6 +47,7 @@ resource "opentelekomcloud_rds_instance_v3" "this" {
   backup_strategy {
     start_time = "03:00-04:00"
     keep_days  = var.backup_keep_days
+    period     = "1,2,3,4,5,6,7"
   }
 
   tags = {


### PR DESCRIPTION
OTC has introduced a breaking change with v1.36.35 and added the mandatory `period` parameter that defines the weekdays when the backup should run.

see https://github.com/opentelekomcloud/terraform-provider-opentelekomcloud/pull/2882