### PR TITLE
feat(aws-terraform-execution): Deny only write operations to this role

### DIFF
--- a/aws-terraform-execution/main.tf
+++ b/aws-terraform-execution/main.tf
@@ -6,9 +6,18 @@ resource "aws_iam_role" "terraform_execution" {
 data "aws_iam_policy_document" "self_control" {
   # Deny updating itself
   statement {
-    sid     = "SelfControl"
-    effect  = "Deny"
-    actions = ["*"]
+    sid    = "SelfControl"
+    effect = "Deny"
+    actions = [
+      "iam:Create*",
+      "iam:Delete*",
+      "iam:Update*",
+      "iam:Put*",
+      "iam:Add*",
+      "iam:Remove*",
+      "iam:Attach*",
+      "iam:Detach*"
+    ]
     resources = [
       aws_iam_role.terraform_execution.arn,
       "${aws_iam_role.terraform_execution.arn}:*",


### PR DESCRIPTION
The EKS model requires to fetch information about the current caller, which needs the GetRole permission on itself