### PR TITLE
feat(otc-kubernetes-cluster): Allow setting different disk types in node pools

### DIFF
--- a/otc-kubernetes-cluster/cce_cluster/main.tf
+++ b/otc-kubernetes-cluster/cce_cluster/main.tf
@@ -106,13 +106,13 @@ resource "opentelekomcloud_cce_node_pool_v3" "this" {
 
   root_volume {
     size       = 40
-    volumetype = "SATA"
+    volumetype = each.value.disk_type != "" && each.value.disk_type != null ? each.value.disk_type : "SATA"
     kms_id     = opentelekomcloud_kms_key_v1.this.id
   }
 
   data_volumes {
     size       = 100
-    volumetype = "SATA"
+    volumetype = each.value.disk_type != "" && each.value.disk_type != null ? each.value.disk_type : "SATA"
     kms_id     = opentelekomcloud_kms_key_v1.this.id
   }
 

--- a/otc-kubernetes-cluster/cce_cluster/variables.tf
+++ b/otc-kubernetes-cluster/cce_cluster/variables.tf
@@ -39,6 +39,7 @@ variable "node_pools" {
   - "min_node_count" (minimum number of nodes in the node pool),
   - "max_node_count" (maximum number of nodes in the node pool),
   - "ssh_public_key" (SSH public key to inject into nodes),
+  - "disk_type" (Disk type for the nodes, e.g., "SAS", "SSD", "GPSSD", "ESSD"),
   - "taints" (list of taints to apply to the nodes in the node pool, each with a key, value, and effect).
   EOF
   type = map(object({
@@ -50,6 +51,7 @@ variable "node_pools" {
     min_node_count    = number
     max_node_count    = number
     ssh_public_key    = string
+    disk_type         = optional(string)
     taints = optional(list(object({
       key    = string
       value  = string


### PR DESCRIPTION
To enable the migration away from deprecated SATA type we need to enable setting the type dynamically. 

**Migration plan:**
1. Spin up new nodes with new disk type
2. Migrate pods
3. Shut down old nodes