### PR TITLE
Create module for credentials and matching K8s manifest

### DIFF
--- a/stackit-credential-manifest/.terraform.lock.hcl
+++ b/stackit-credential-manifest/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = ">= 2.6.1"
+  hashes = [
+    "h1:DbiR/D2CPigzCGweYIyJH0N0x04oyI5xiZ9wSW/s3kQ=",
+    "zh:10050d08f416de42a857e4b6f76809aae63ea4ec6f5c852a126a915dede814b4",
+    "zh:2df2a3ebe9830d4759c59b51702e209fe053f47453cb4688f43c063bac8746b7",
+    "zh:2e759568bcc38c86ca0e43701d34cf29945736fdc8e429c5b287ddc2703c7b18",
+    "zh:6a62a34e48500ab4aea778e355e162ebde03260b7a9eb9edc7e534c84fbca4c6",
+    "zh:74373728ba32a1d5450a3a88ac45624579e32755b086cd4e51e88d9aca240ef6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8dddae588971a996f622e7589cd8b9da7834c744ac12bfb59c97fa77ded95255",
+    "zh:946f82f66353bb97aefa8d95c4ca86db227f9b7c50b82415289ac47e4e74d08d",
+    "zh:e9a5c09e6f35e510acf15b666fd0b34a30164cecdcd81ce7cda0f4b2dade8d91",
+    "zh:eafe5b873ef42b32feb2f969c38ff8652507e695620cbaf03b9db714bee52249",
+    "zh:ec146289fa27650c9d433bb5c7847379180c0b7a323b1b94e6e7ad5d2a7dbe71",
+    "zh:fc882c35ce05631d76c0973b35adde26980778fc81d9da81a2fade2b9d73423b",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.7.2"
+  constraints = ">= 3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "5.6.0"
+  constraints = ">= 5.3.0"
+  hashes = [
+    "h1:X7NkQUw1neyK2wS1HWFrwwwKNmgz9UHRXudeqJuBPi0=",
+    "zh:062bfab310e25164ea1bd9a2b86eb0e07ebf67d66f1cea32af84432a8a0a3f15",
+    "zh:0fbff85de06502af491dc1992a1a9de5b7066d9dd12095350c73cd9e2a80d11e",
+    "zh:255dd6c50d9f069486b36ed13612a1fb7fcaed1949861fb6bc1681bd668ab223",
+    "zh:2e99f2dbff55363e1b97370858735a1a8f680d4f4ff28e4665727bafd504d253",
+    "zh:3deba8d0c6987cf4613664ec46be0caa071621295a51135a6142742bd73e9c9c",
+    "zh:50b6660462cc9fb20b8343c5e11fa7d026e5f805c96223b032eb10de76583349",
+    "zh:6338f19114edc8b754bfc8c144d37c71dd6b1a511d388e0118f5eac446a8c5eb",
+    "zh:6671aeecd9f056509612b22c20cf5c52392bd7ca52ee5db9988e68d34cde2c8d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:944692c575f710ff6412efecee401b56981df7cfe2ae6a0c0e54b7c38a92934e",
+    "zh:d5a73da30ac8db0ecc4bf4bab733ddcad009ae768d30dc6ae212db2e1d1ad34f",
+    "zh:fbd46583f3037a85cbc5995e15bb72a08903e9afc5a06dd9b23de251efc58225",
+  ]
+}

--- a/stackit-credential-manifest/README.md
+++ b/stackit-credential-manifest/README.md
@@ -1,0 +1,69 @@
+# STACKIT Credential Manifest Module
+
+This module creates a credential pair (user/password) with a random password that is stored in the provided STACKIT Secrets Manager.
+It will also create a manifest file to be used by Kubernetes so you can expose the credentials to your services.
+
+## Example
+
+```hcl
+locals {
+  db_users = toset(["poweruser", "reader"])
+}
+
+
+module "my_users" {
+  source   = "github.com/digitalservicebund/terraform-modules//stackit-credential-manifest?ref=[sha of the commit you want to use]"
+  
+  for_each = local.db_users
+  vault_name                 = "postgres"
+  user                       = each.key
+  manifest_name              = "database-${each.key}-credentials" 
+  manifest_file              = "../../manifests/overlays/staging-stackit/database-${each.key}-secret.yaml"
+  secret_manager_instance_id = local.secret_manager_instance_id
+  kubernetes_namespace       = local.kubernetes_namespace
+}
+
+```
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >1.10.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >=2.6.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >=3.7.2 |
+| <a name="requirement_vault"></a> [vault](#requirement\_vault) | >=5.3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+| <a name="provider_vault"></a> [vault](#provider\_vault) | 5.6.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [local_file.external_secret_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [random_password.password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [vault_kv_secret_v2.credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `"[your-namespace]"` | no |
+| <a name="input_manifest_file"></a> [manifest\_file](#input\_manifest\_file) | Path to the new file | `string` | n/a | yes |
+| <a name="input_manifest_name"></a> [manifest\_name](#input\_manifest\_name) | Kubernetes MetaData Name property | `string` | n/a | yes |
+| <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id) | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_user\_password is true. | `string` | `""` | no |
+| <a name="input_user"></a> [user](#input\_user) | Specifies the user the credentials are created for | `string` | n/a | yes |
+| <a name="input_vault_name"></a> [vault\_name](#input\_vault\_name) | Specifies the Vault name the credentials will be stored under | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_secret_manager_secret_name"></a> [secret\_manager\_secret\_name](#output\_secret\_manager\_secret\_name) | Name of the secret in STACKIT Secrets Manager where the credentials are stored |
+<!-- END_TF_DOCS -->

--- a/stackit-credential-manifest/main.tf
+++ b/stackit-credential-manifest/main.tf
@@ -1,0 +1,51 @@
+resource "random_password" "password" {
+  length           = 32
+  special          = true
+  override_special = "~!@#%^*-_=+?"
+}
+
+resource "vault_kv_secret_v2" "credentials" {
+  mount = var.secret_manager_instance_id
+  name  = "${var.vault_name}/${var.user}"
+  data_json = jsonencode({
+    username = var.user
+    password = random_password.password.result
+  })
+}
+
+resource "local_file" "external_secret_manifest" {
+  filename = var.manifest_file
+
+  # We construct the YAML content directly here
+  content = yamlencode({
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "${var.manifest_name}"
+      namespace = "${var.kubernetes_namespace}"
+    }
+    spec = {
+      refreshInterval = "15m"
+      secretStoreRef = {
+        name = "secret-store"
+        kind = "SecretStore"
+      }
+      data = [
+        {
+          secretKey = "username"
+          remoteRef = {
+            key      = "${var.vault_name}/${var.user}"
+            property = "username"
+          }
+        },
+        {
+          secretKey = "$password"
+          remoteRef = {
+            key      = "${var.vault_name}/${var.user}"
+            property = "password"
+          }
+        }
+      ]
+    }
+  })
+}

--- a/stackit-credential-manifest/outputs.tf
+++ b/stackit-credential-manifest/outputs.tf
@@ -1,0 +1,4 @@
+output "secret_manager_secret_name" {
+  description = "Name of the secret in STACKIT Secrets Manager where the credentials are stored"
+  value       = vault_kv_secret_v2.credentials.name
+}

--- a/stackit-credential-manifest/terraform.tf
+++ b/stackit-credential-manifest/terraform.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">1.10.0"
+
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">=5.3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">=2.6.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">=3.7.2"
+    }
+  }
+}

--- a/stackit-credential-manifest/tests/credentials.tftest.hcl
+++ b/stackit-credential-manifest/tests/credentials.tftest.hcl
@@ -1,0 +1,45 @@
+mock_provider "vault" {}
+
+variables {
+  secret_manager_instance_id = "test-mount"
+  vault_name                 = "test-vault"
+  user                       = "test-user"
+  manifest_file              = "test-output.yaml"
+  manifest_name              = "test-secret-name"
+  kubernetes_namespace       = "test-namespace"
+}
+
+
+run "create_credentials" {
+  command = apply
+
+  assert {
+    condition     = length(random_password.password.result) == 32
+    error_message = "Password length must be exactly 32 characters."
+  }
+
+  assert {
+    condition     = can(regex("^[~!@#%^*\\-_=+?a-zA-Z0-9]+$", random_password.password.result))
+    error_message = "Password contains invalid characters."
+  }
+
+  assert {
+    condition     = vault_kv_secret_v2.credentials.name == "test-vault/test-user"
+    error_message = "Vault secret path (name) is constructed incorrectly."
+  }
+
+  assert {
+    condition     = yamldecode(local_file.external_secret_manifest.content).kind == "ExternalSecret"
+    error_message = "Generated YAML 'kind' is not 'ExternalSecret'."
+  }
+
+  assert {
+    condition     = yamldecode(local_file.external_secret_manifest.content).metadata.namespace == "test-namespace"
+    error_message = "Namespace in YAML does not match the input variable."
+  }
+
+  assert {
+    condition     = yamldecode(local_file.external_secret_manifest.content).spec.data[0].remoteRef.key == "test-vault/test-user"
+    error_message = "RemoteRef Key in YAML is incorrect."
+  }
+}

--- a/stackit-credential-manifest/variables.tf
+++ b/stackit-credential-manifest/variables.tf
@@ -1,0 +1,31 @@
+variable "vault_name" {
+  description = "Specifies the Vault name the credentials will be stored under"
+  type        = string
+}
+
+variable "user" {
+  description = "Specifies the user the credentials are created for"
+  type        = string
+}
+
+variable "manifest_file" {
+  description = "Path to the new file"
+  type        = string
+}
+
+variable "manifest_name" {
+  description = "Kubernetes MetaData Name property"
+  type        = string
+}
+
+variable "secret_manager_instance_id" {
+  description = "Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage_user_password is true."
+  type        = string
+  default     = ""
+}
+
+variable "kubernetes_namespace" {
+  description = "Kubernetes namespace where the External Secret manifest will be applied."
+  type        = string
+  default     = "[your-namespace]"
+}


### PR DESCRIPTION
Create a user/password credential pair in a Vault and export manifest resource.

This can then be reused to create multiple database users and manifest files.

E.g. for neuris-infra, I could then do something like:
```
locals {
  db_users = toset(["migration", "caselaw", "norms", "search", "literature"])
}


module "database_users" {
  source   = "/Users/marcel/Development/git/digitalservice/terraform-modules//stackit-credential-manifest"
  
  for_each = local.db_users
  vault_name                 = "postgres"
  user                       = each.key
  manifest_name              = "database-${each.key}-credentials" 
  manifest_file              = "../../manifests/overlays/staging-stackit/database-${each.key}-secret.yaml"
  secret_manager_instance_id = local.secret_manager_instance_id
  kubernetes_namespace       = local.kubernetes_namespace
}
```

Or would this better be located at a local `modules` folder within neuris-infra?