### PR TITLE
Create more than one user and database when configured

### DIFF
--- a/stackit-postgres-db/.terraform.lock.hcl
+++ b/stackit-postgres-db/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = ">= 2.6.1"
+  hashes = [
+    "h1:DbiR/D2CPigzCGweYIyJH0N0x04oyI5xiZ9wSW/s3kQ=",
+    "zh:10050d08f416de42a857e4b6f76809aae63ea4ec6f5c852a126a915dede814b4",
+    "zh:2df2a3ebe9830d4759c59b51702e209fe053f47453cb4688f43c063bac8746b7",
+    "zh:2e759568bcc38c86ca0e43701d34cf29945736fdc8e429c5b287ddc2703c7b18",
+    "zh:6a62a34e48500ab4aea778e355e162ebde03260b7a9eb9edc7e534c84fbca4c6",
+    "zh:74373728ba32a1d5450a3a88ac45624579e32755b086cd4e51e88d9aca240ef6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8dddae588971a996f622e7589cd8b9da7834c744ac12bfb59c97fa77ded95255",
+    "zh:946f82f66353bb97aefa8d95c4ca86db227f9b7c50b82415289ac47e4e74d08d",
+    "zh:e9a5c09e6f35e510acf15b666fd0b34a30164cecdcd81ce7cda0f4b2dade8d91",
+    "zh:eafe5b873ef42b32feb2f969c38ff8652507e695620cbaf03b9db714bee52249",
+    "zh:ec146289fa27650c9d433bb5c7847379180c0b7a323b1b94e6e7ad5d2a7dbe71",
+    "zh:fc882c35ce05631d76c0973b35adde26980778fc81d9da81a2fade2b9d73423b",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/vault" {
   version     = "5.3.0"
   constraints = ">= 5.3.0"

--- a/stackit-postgres-db/README.md
+++ b/stackit-postgres-db/README.md
@@ -98,7 +98,7 @@ When the variable is not set, the manifest will not be created.
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Specifies the storage performance class. e.g. premium-perf6-stackit | `string` | `"premium-perf6-stackit"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Specifies the postgres version. | `string` | `"17"` | no |
 | <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest) | Path where the external secret manifest will be stored at | `string` | `null` | no |
-| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `"[your-namespace]"` | no |
+| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `null` | no |
 | <a name="input_manage_user_password"></a> [manage\_user\_password](#input\_manage\_user\_password) | Set true to add the user password into the STACKIT Secrets Manager. | `bool` | `true` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Specifies the memory (RAM) specs of the instance in GB. Available Options: 4, 8, 16, 32 & 128 | `number` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Specifies the name of the Postgres instance. | `string` | n/a | yes |

--- a/stackit-postgres-db/README.md
+++ b/stackit-postgres-db/README.md
@@ -29,8 +29,9 @@ To minimize configuration for simple use cases, this module uses "Convention ove
   user_names     = ["additional", "user"] # optional
 
   secret_manager_instance_id = "[your secrets manager instance id]" # available as output from stackit-secrets-manager module
-  kubernetes_namespace = "[your-namespace]" # Namespace where the External Secret manifest will be applied
-  manifest_filename = "[path-to-the-manifest-file-to-be-created]" # The path in your system the manifest will be stored at
+  kubernetes_namespace       = "[your-namespace]" # Namespace where the External Secret manifest will be applied
+  external_secret_manifest   = "[path-to-the-manifest-file-to-be-created]" # The path in your system the external secret manifest will be stored at
+  config_map_manifest        = "[patth-to-the-manifestt-file-to-be-created" # The path in your system the config map manifest will be stored at
 } 
 ```
 
@@ -41,6 +42,16 @@ If `manage_user_password` is set to `true` (default):
 1.  **Vault Storage:** The module generates strong passwords and stores them in your STACKIT Secrets Manager instance.
 2.  **Manifest Generation:** It generates a local YAML file containing an `ExternalSecret` resource.
 3.  **Kubernetes Sync:** You can apply this manifest to your cluster. The External Secrets Operator will then fetch the credentials from Secrets Manager
+
+## Kubernetes Config Maps
+
+If `config_map_manifest` is set, then the module will also create a manifest file with the following contents per defined databases:
+
+- database: <name of database>
+- host: <host of database instance>
+- port: <port of database instance>
+
+When the variable is not set, the manifest will not be created.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -64,6 +75,7 @@ If `manage_user_password` is set to `true` (default):
 
 | Name | Type |
 |------|------|
+| [local_file.config_map_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.external_secret_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [stackit_postgresflex_database.database](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/postgresflex_database) | resource |
 | [stackit_postgresflex_instance.this](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/postgresflex_instance) | resource |
@@ -79,14 +91,15 @@ If `manage_user_password` is set to `true` (default):
 | <a name="input_acls"></a> [acls](#input\_acls) | List of ACL IDs to associate with the database instance. This should be the cluster Egress IP Range only! | `list(string)` | n/a | yes |
 | <a name="input_admin_name"></a> [admin\_name](#input\_admin\_name) | Specified the name of the Postgres Database Owner | `string` | `null` | no |
 | <a name="input_backup_schedule"></a> [backup\_schedule](#input\_backup\_schedule) | Backup schedule in cron format. Defaults to daily at 3am UTC. | `string` | `"0 3 * * *"` | no |
+| <a name="input_config_map_manifest"></a> [config\_map\_manifest](#input\_config\_map\_manifest) | Path where the config map manifest will be stored at | `string` | `null` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | Specifies the CPU specs of the instance. Available Options: 2, 4, 8 & 16 | `number` | n/a | yes |
 | <a name="input_database_names"></a> [database\_names](#input\_database\_names) | List of database names to create. If empty, defaults to a single database named after the instance. | `set(string)` | `[]` | no |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of the instance disk volume. Its value range is from 5 GB to 4000 GB. | `number` | n/a | yes |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Specifies the storage performance class. e.g. premium-perf6-stackit | `string` | `"premium-perf6-stackit"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Specifies the postgres version. | `string` | `"17"` | no |
+| <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest) | Path where the external secret manifest will be stored at | `string` | `null` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `"[your-namespace]"` | no |
 | <a name="input_manage_user_password"></a> [manage\_user\_password](#input\_manage\_user\_password) | Set true to add the user password into the STACKIT Secrets Manager. | `bool` | `true` | no |
-| <a name="input_manifest_filename"></a> [manifest\_filename](#input\_manifest\_filename) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `null` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Specifies the memory (RAM) specs of the instance in GB. Available Options: 4, 8, 16, 32 & 128 | `number` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Specifies the name of the Postgres instance. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the STACKIT project where the database will be created. | `string` | n/a | yes |

--- a/stackit-postgres-db/README.md
+++ b/stackit-postgres-db/README.md
@@ -1,40 +1,46 @@
 # STACKIT Postgres Database Module
 
-This module creates a managed Postgres database on STACKIT. Creates a database server instance, a database with the same
-name and a user with the same username that is also the owner of the database.
+This module provisions a managed PostgreSQL database instance on STACKIT. It handles the creation of the instance, databases, and users, while optionally integrating with STACKIT Secrets Manager for secure credential storage.
 
-By default, the credentials for the database user are stored in the STACKIT Secrets Manager and a Kubernetes External Secret
-manifest is provided to fetch the credentials from there. 
+## Configuration Logic
 
-## Example
+To minimize configuration for simple use cases, this module uses "Convention over Configuration" with fallback logic:
+
+| Resource | Logic |
+| :--- | :--- |
+| **Databases** | Creates databases listed in `database_names`. <br> *Fallback:* If the list is empty, creates a single database named after the instance (`var.name`). |
+| **Admin User** | Creates an admin user named `admin_user`. <br> *Fallback:* If not set, creates a user named after the instance (`var.name`). |
+
+## Usage Example
 
 ```hcl
-module "database" {
+ module "database" {
   source         = "github.com/digitalservicebund/terraform-modules//stackit-postgres-db?ref=[sha of the commit you want to use]"
   project_id     = "[your stackit project id]"
-  name           = "[database name]"
+  name           = "[database instance name]"
   cpu            = 2
   memory         = 4
   engine_version = "17"
   disk_size      = 5
   acls           = "[cluster egress range]" # Ask the platform team for the correct egress range
-  
+
+  database_names = ["list-of-names", "to-create-databases"] # optional, will fallback to `var.name` if not present
+  admin_name     = "root" # optional, will fallback to `var.name` if not present
+  user_names     = ["additional", "user"] # optional
+
   secret_manager_instance_id = "[your secrets manager instance id]" # available as output from stackit-secrets-manager module
   kubernetes_namespace = "[your-namespace]" # Namespace where the External Secret manifest will be applied
-}
-
-# Write the External Secret manifest to a file, null_resources will only be executed once, so you can keep them.
-# Please adjust the path to your kustomize overlay accordingly.
-resource "null_resource" "external_secret" {
-  provisioner "local-exec" {
-    command = <<-EOT
-cat <<EOF > ../path/to/overlay/external-secret-manifest.yaml
-${module.database.external_secret_manifest}
-EOF
-    EOT
-  }
-}
+  manifest_filename = "[path-to-the-manifest-file-to-be-created]" # The path in your system the manifest will be stored at
+} 
 ```
+
+## Secrets & Kubernetes Integration
+
+If `manage_user_password` is set to `true` (default):
+
+1.  **Vault Storage:** The module generates strong passwords and stores them in your STACKIT Secrets Manager instance.
+2.  **Manifest Generation:** It generates a local YAML file containing an `ExternalSecret` resource.
+3.  **Kubernetes Sync:** You can apply this manifest to your cluster. The External Secrets Operator will then fetch the credentials from Secrets Manager
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -42,6 +48,7 @@ EOF
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >1.10.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >=2.6.1 |
 | <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >=0.65.0 |
 | <a name="requirement_vault"></a> [vault](#requirement\_vault) | >=5.3.0 |
 
@@ -49,6 +56,7 @@ EOF
 
 | Name | Version |
 |------|---------|
+| <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
 | <a name="provider_stackit"></a> [stackit](#provider\_stackit) | 0.68.0 |
 | <a name="provider_vault"></a> [vault](#provider\_vault) | 5.3.0 |
 
@@ -56,36 +64,42 @@ EOF
 
 | Name | Type |
 |------|------|
+| [local_file.external_secret_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [stackit_postgresflex_database.database](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/postgresflex_database) | resource |
 | [stackit_postgresflex_instance.this](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/postgresflex_instance) | resource |
+| [stackit_postgresflex_user.admin](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/postgresflex_user) | resource |
 | [stackit_postgresflex_user.user](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/postgresflex_user) | resource |
-| [vault_kv_secret_v2.postgres_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
+| [vault_kv_secret_v2.postgres_admin_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
+| [vault_kv_secret_v2.postgres_user_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acls"></a> [acls](#input\_acls) | List of ACL IDs to associate with the database instance. This should be the cluster Egress IP Range only! | `list(string)` | n/a | yes |
+| <a name="input_admin_name"></a> [admin\_name](#input\_admin\_name) | Specified the name of the Postgres Database Owner | `string` | `null` | no |
 | <a name="input_backup_schedule"></a> [backup\_schedule](#input\_backup\_schedule) | Backup schedule in cron format. Defaults to daily at 3am UTC. | `string` | `"0 3 * * *"` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | Specifies the CPU specs of the instance. Available Options: 2, 4, 8 & 16 | `number` | n/a | yes |
+| <a name="input_database_names"></a> [database\_names](#input\_database\_names) | List of database names to create. If empty, defaults to a single database named after the instance. | `set(string)` | `[]` | no |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of the instance disk volume. Its value range is from 5 GB to 4000 GB. | `number` | n/a | yes |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Specifies the storage performance class. e.g. premium-perf6-stackit | `string` | `"premium-perf6-stackit"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Specifies the postgres version. | `string` | `"17"` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `"[your-namespace]"` | no |
 | <a name="input_manage_user_password"></a> [manage\_user\_password](#input\_manage\_user\_password) | Set true to add the user password into the STACKIT Secrets Manager. | `bool` | `true` | no |
+| <a name="input_manifest_filename"></a> [manifest\_filename](#input\_manifest\_filename) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `null` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Specifies the memory (RAM) specs of the instance in GB. Available Options: 4, 8, 16, 32 & 128 | `number` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Specifies the name of the Postgres instance. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the STACKIT project where the database will be created. | `string` | n/a | yes |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of read replicas for the instance. | `number` | `1` | no |
 | <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id) | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_user\_password is true. | `string` | `""` | no |
+| <a name="input_user_names"></a> [user\_names](#input\_user\_names) | List of additional database users to create. Elements must be unique. | `set(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_address"></a> [address](#output\_address) | Database host address |
-| <a name="output_external_secret_manifest"></a> [external\_secret\_manifest](#output\_external\_secret\_manifest) | Kubernetes External Secret manifest to fetch the database credentials from STACKIT Secrets Manager |
-| <a name="output_password"></a> [password](#output\_password) | Database password. This will be emtpy if the password is managed in STACKIT Secrets Manager. |
-| <a name="output_secret_manager_secret_name"></a> [secret\_manager\_secret\_name](#output\_secret\_manager\_secret\_name) | Name of the secret in STACKIT Secrets Manager where the database credentials are stored |
-| <a name="output_username"></a> [username](#output\_username) | Database username |
+| <a name="output_passwords"></a> [passwords](#output\_passwords) | Map of user keys to passwords. Empty if managed in Secrets Manager. |
+| <a name="output_secret_manager_secret_names"></a> [secret\_manager\_secret\_names](#output\_secret\_manager\_secret\_names) | List of secret paths created in STACKIT Secrets Manager |
+| <a name="output_usernames"></a> [usernames](#output\_usernames) | List of all database usernames (admin + standard users) |
 <!-- END_TF_DOCS -->

--- a/stackit-postgres-db/README.md
+++ b/stackit-postgres-db/README.md
@@ -112,7 +112,6 @@ When the variable is not set, the manifest will not be created.
 | Name | Description |
 |------|-------------|
 | <a name="output_address"></a> [address](#output\_address) | Database host address |
-| <a name="output_passwords"></a> [passwords](#output\_passwords) | Map of user keys to passwords. Empty if managed in Secrets Manager. |
+| <a name="output_credentials"></a> [credentials](#output\_credentials) | Map of user keys to passwords. Empty if managed in Secrets Manager. |
 | <a name="output_secret_manager_secret_names"></a> [secret\_manager\_secret\_names](#output\_secret\_manager\_secret\_names) | List of secret paths created in STACKIT Secrets Manager |
-| <a name="output_usernames"></a> [usernames](#output\_usernames) | List of all database usernames (admin + standard users) |
 <!-- END_TF_DOCS -->

--- a/stackit-postgres-db/main.tf
+++ b/stackit-postgres-db/main.tf
@@ -113,10 +113,6 @@ resource "local_file" "external_secret_manifest" {
           {
             secretKey = "${local.admin_user}_password"
             remoteRef = { key = "postgres/${local.admin_user}", property = "password" }
-          },
-          {
-            secretKey = "database_host"
-            remoteRef = { key = "postgres/${local.admin_user}", property = "host" }
           }
         ],
         flatten([

--- a/stackit-postgres-db/main.tf
+++ b/stackit-postgres-db/main.tf
@@ -84,8 +84,8 @@ resource "local_file" "external_secret_manifest" {
     precondition {
       # Only create the file if manage_user_password is set (otherwise the resource would not be created at all)
       # and error out if the filename was not provided.
-      condition     = var.external_secret_manifest != null
-      error_message = "You enabled 'manage_user_password' but did not provide a 'manifest_filename'."
+      condition     = var.external_secret_manifest != null && var.kubernetes_namespace != null
+      error_message = "You enabled 'manage_user_password' but did not provide 'manifest_filename' and 'kubernetes_namespace'."
     }
   }
 
@@ -135,6 +135,12 @@ resource "local_file" "external_secret_manifest" {
 resource "local_file" "config_map_manifest" {
   count = var.config_map_manifest != null ? 1 : 0
 
+  lifecycle {
+    precondition {
+      condition     = var.kubernetes_namespace != null
+      error_message = "You enabled 'config_map_manifest' but did not provide 'kubernetes_namespace'."
+    }
+  }
   filename = var.config_map_manifest
 
   content = join("\n---\n", [

--- a/stackit-postgres-db/main.tf
+++ b/stackit-postgres-db/main.tf
@@ -111,7 +111,7 @@ resource "local_file" "external_secret_manifest" {
             remoteRef = { key = "postgres/${local.admin_user}", property = "username" }
           },
           {
-            secretKey = "admin_password"
+            secretKey = "${local.admin_user}_password"
             remoteRef = { key = "postgres/${local.admin_user}", property = "password" }
           },
           {

--- a/stackit-postgres-db/main.tf
+++ b/stackit-postgres-db/main.tf
@@ -1,3 +1,11 @@
+locals {
+  # If database_names is empty, default to a set containing just the instance name.
+  # Otherwise, use the provided set.
+  databases = length(var.database_names) == 0 ? toset([var.name]) : var.database_names
+  # Create the admin user with the name of the instance if not set explicitly
+  admin_user = coalesce(var.admin_name, var.name)
+}
+
 resource "stackit_postgresflex_instance" "this" {
   project_id      = var.project_id
   name            = var.name
@@ -15,27 +23,115 @@ resource "stackit_postgresflex_instance" "this" {
   version = var.engine_version
 }
 
-resource "stackit_postgresflex_database" "database" {
+resource "stackit_postgresflex_user" "admin" {
   project_id  = var.project_id
   instance_id = stackit_postgresflex_instance.this.instance_id
-  name        = var.name
-  owner       = stackit_postgresflex_user.user.username
+  roles       = ["login", "createdb"]
+  username    = local.admin_user
+}
+
+resource "stackit_postgresflex_database" "database" {
+  for_each = local.databases # Simple set iteration
+
+  project_id  = var.project_id
+  instance_id = stackit_postgresflex_instance.this.instance_id
+  name        = each.key
+  owner       = stackit_postgresflex_user.admin.username
 }
 
 resource "stackit_postgresflex_user" "user" {
+  for_each = var.user_names # Simple set iteration
+
   project_id  = var.project_id
   instance_id = stackit_postgresflex_instance.this.instance_id
   roles       = ["login"]
-  username    = var.name
+  username    = each.key
 }
 
-resource "vault_kv_secret_v2" "postgres_credentials" {
+
+resource "vault_kv_secret_v2" "postgres_admin_credentials" {
+  # Create only if enabled
   count = var.manage_user_password ? 1 : 0
+
   mount = var.secret_manager_instance_id
-  name  = "postgres/${stackit_postgresflex_user.user.username}"
+  name  = "postgres/${stackit_postgresflex_user.admin.username}"
+
   data_json = jsonencode({
-    username = stackit_postgresflex_user.user.username
-    password = stackit_postgresflex_user.user.password
-    host     = stackit_postgresflex_user.user.host
+    username = stackit_postgresflex_user.admin.username
+    password = stackit_postgresflex_user.admin.password
+    host     = stackit_postgresflex_user.admin.host
+  })
+}
+
+resource "vault_kv_secret_v2" "postgres_user_credentials" {
+  # Loop over users only if enabled
+  for_each = var.manage_user_password ? var.user_names : []
+
+  mount = var.secret_manager_instance_id
+  name  = "postgres/${stackit_postgresflex_user.user[each.key].username}"
+
+  data_json = jsonencode({
+    username = stackit_postgresflex_user.user[each.key].username
+    password = stackit_postgresflex_user.user[each.key].password
+    host     = stackit_postgresflex_user.user[each.key].host
+  })
+}
+
+resource "local_file" "external_secret_manifest" {
+  count = var.manage_user_password ? 1 : 0
+
+  lifecycle {
+    precondition {
+      # Only create the file if manage_user_password is set (otherwise the resource would not be created at all)
+      # and error out if the filename was not provided.
+      condition     = var.manifest_filename != null
+      error_message = "You enabled 'manage_user_password' but did not provide a 'manifest_filename'."
+    }
+  }
+
+  filename = var.manifest_filename
+
+  content = yamlencode({
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "database-credentials"
+      namespace = var.kubernetes_namespace
+    }
+    spec = {
+      refreshInterval = "15m"
+      secretStoreRef = {
+        name = "secret-store"
+        kind = "SecretStore"
+      }
+      data = concat(
+        [
+          {
+            secretKey = "${local.admin_user}_user"
+            remoteRef = { key = "postgres/${local.admin_user}", property = "username" }
+          },
+          {
+            secretKey = "admin_password"
+            remoteRef = { key = "postgres/${local.admin_user}", property = "password" }
+          },
+          {
+            secretKey = "database_host"
+            remoteRef = { key = "postgres/${local.admin_user}", property = "host" }
+          }
+        ],
+        flatten([
+          for user in var.user_names : [
+            {
+              secretKey = "${user}_user"
+              remoteRef = { key = "postgres/${user}", property = "username" }
+            },
+            {
+              secretKey = "${user}_password"
+              remoteRef = { key = "postgres/${user}", property = "password" }
+            }
+          ]
+        ])
+      )
+    }
   })
 }

--- a/stackit-postgres-db/outputs.tf
+++ b/stackit-postgres-db/outputs.tf
@@ -3,15 +3,7 @@ output "address" {
   value       = stackit_postgresflex_user.admin.host
 }
 
-output "usernames" {
-  description = "List of all database usernames (admin + standard users)"
-  value = concat(
-    [stackit_postgresflex_user.admin.username],
-    values(stackit_postgresflex_user.user)[*].username
-  )
-}
-
-output "passwords" {
+output "credentials" {
   description = "Map of user keys to passwords. Empty if managed in Secrets Manager."
   sensitive   = true
   value = merge(

--- a/stackit-postgres-db/outputs.tf
+++ b/stackit-postgres-db/outputs.tf
@@ -1,53 +1,32 @@
 output "address" {
   description = "Database host address"
-  value       = stackit_postgresflex_user.user.host
+  value       = stackit_postgresflex_user.admin.host
 }
 
-output "username" {
-  description = "Database username"
-  value       = stackit_postgresflex_user.user.username
+output "usernames" {
+  description = "List of all database usernames (admin + standard users)"
+  value = concat(
+    [stackit_postgresflex_user.admin.username],
+    values(stackit_postgresflex_user.user)[*].username
+  )
 }
 
-output "password" {
-  description = "Database password. This will be emtpy if the password is managed in STACKIT Secrets Manager."
-  value       = var.manage_user_password ? "" : stackit_postgresflex_user.user.password
+output "passwords" {
+  description = "Map of user keys to passwords. Empty if managed in Secrets Manager."
   sensitive   = true
+  value = merge(
+    { (stackit_postgresflex_user.admin.username) = var.manage_user_password ? "" : stackit_postgresflex_user.admin.password },
+    {
+      for user in var.user_names :
+      user => var.manage_user_password ? "" : stackit_postgresflex_user.user[user].password
+    }
+  )
 }
 
-output "secret_manager_secret_name" {
-  description = "Name of the secret in STACKIT Secrets Manager where the database credentials are stored"
-  value       = var.manage_user_password ? vault_kv_secret_v2.postgres_credentials[0].name : ""
-}
-
-
-locals {
-  external_secrets_manifest = <<EOF
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: database-credentials
-  namespace: ${var.kubernetes_namespace}
-spec:
-  refreshInterval: "15m"
-  secretStoreRef:
-    name: secret-store
-    kind: SecretStore
-  data:
-    - secretKey: username
-      remoteRef:
-        key: ${var.manage_user_password ? vault_kv_secret_v2.postgres_credentials[0].name : ""}
-        property: username
-    - secretKey: password
-      remoteRef:
-        key: ${var.manage_user_password ? vault_kv_secret_v2.postgres_credentials[0].name : ""}
-        property: password
-    - secretKey: host
-      remoteRef:
-        key: ${var.manage_user_password ? vault_kv_secret_v2.postgres_credentials[0].name : ""}
-        property: host
-EOF
-}
-output "external_secret_manifest" {
-  description = "Kubernetes External Secret manifest to fetch the database credentials from STACKIT Secrets Manager"
-  value       = var.manage_user_password ? local.external_secrets_manifest : ""
+output "secret_manager_secret_names" {
+  description = "List of secret paths created in STACKIT Secrets Manager"
+  value = var.manage_user_password ? concat(
+    [vault_kv_secret_v2.postgres_admin_credentials[0].name],
+    values(vault_kv_secret_v2.postgres_user_credentials)[*].name
+  ) : []
 }

--- a/stackit-postgres-db/terraform.tf
+++ b/stackit-postgres-db/terraform.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = ">1.10.0"
 
   required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = ">=2.6.1"
+    }
     stackit = {
       source  = "stackitcloud/stackit"
       version = ">=0.65.0"

--- a/stackit-postgres-db/tests/postgres.tftest.hcl
+++ b/stackit-postgres-db/tests/postgres.tftest.hcl
@@ -97,23 +97,13 @@ run "basic_creation" {
   }
 
   assert {
-    condition     = contains(output.usernames, "root")
-    error_message = "Usernames list should contain 'root'"
+    condition     = nonsensitive(output.credentials["root"]) == "password"
+    error_message = "Admin user and password should be available"
   }
 
   assert {
-    condition     = contains(output.usernames, "migration")
-    error_message = "Usernames list should contain 'migration'"
-  }
-
-  assert {
-    condition     = nonsensitive(output.passwords["root"]) == "password"
-    error_message = "The password should be available as output"
-  }
-
-  assert {
-    condition     = nonsensitive(output.passwords["migration"]) == "password"
-    error_message = "The password should be available as output"
+    condition     = nonsensitive(output.credentials["migration"]) == "password"
+    error_message = "User and password should be available"
   }
 
 }

--- a/stackit-postgres-db/tests/postgres.tftest.hcl
+++ b/stackit-postgres-db/tests/postgres.tftest.hcl
@@ -18,7 +18,16 @@ mock_provider "vault" {
 }
 
 variables {
-  project_id = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
+  project_id     = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
+  name           = "test-postgres"
+  cpu            = 2
+  memory         = 4
+  engine_version = "17"
+  disk_size      = 10
+  acls           = ["10.0.0.0/16"]
+  admin_name     = "root"
+
+  kubernetes_namespace = "namespace"
 }
 
 # --- Test 1: Basic Creation ---
@@ -26,20 +35,10 @@ run "basic_creation" {
   command = apply
 
   variables {
-    name           = "test-postgres"
-    project_id     = var.project_id
-    cpu            = 2
-    memory         = 4
-    engine_version = "17"
-    disk_size      = 10
-    acls           = ["10.0.0.0/16"]
-
     database_names = ["neuris", "metabase"]
-    admin_name     = "root"
     user_names     = ["migration", "search"]
 
     manage_user_password = false
-    kubernetes_namespace = "namespace"
   }
 
   assert {
@@ -112,22 +111,15 @@ run "secrets_and_manifest" {
   command = apply
 
   variables {
-    name       = "test-secrets"
-    project_id = var.project_id
-    cpu        = 2
-    memory     = 4
-    disk_size  = 10
-    acls       = ["0.0.0.0/0"]
+    name = "test-secrets"
 
     database_names = ["neuris"]
-    admin_name     = "root"
     user_names     = ["migration"]
 
     manage_user_password       = true
     secret_manager_instance_id = "mock-vault"
 
     external_secret_manifest = "output.yaml"
-    kubernetes_namespace     = "platform"
   }
 
   assert {
@@ -173,16 +165,9 @@ run "validation_missing_external_secret_manifest" {
   command = plan
 
   variables {
-    name       = "fail-test"
-    project_id = var.project_id
-    cpu        = 2
-    memory     = 4
-    disk_size  = 10
-    acls       = []
-
+    name                     = "fail-test"
     manage_user_password     = true
     external_secret_manifest = null
-    kubernetes_namespace     = "namespace"
   }
 
   # We want to mnanage the secrets externally but forgot to specify the K8s manifest file path to glue things together
@@ -208,7 +193,6 @@ run "config_map_manifest" {
     user_names     = ["migration", "search"]
 
     manage_user_password = false
-    kubernetes_namespace = "namespace"
     config_map_manifest  = "configmap.yaml"
   }
   assert {

--- a/stackit-postgres-db/variables.tf
+++ b/stackit-postgres-db/variables.tf
@@ -89,7 +89,7 @@ variable "secret_manager_instance_id" {
 variable "kubernetes_namespace" {
   description = "Kubernetes namespace where the External Secret manifest will be applied."
   type        = string
-  default     = "[your-namespace]"
+  default     = null
 }
 
 variable "external_secret_manifest" {

--- a/stackit-postgres-db/variables.tf
+++ b/stackit-postgres-db/variables.tf
@@ -3,6 +3,24 @@ variable "name" {
   type        = string
 }
 
+variable "admin_name" {
+  description = "Specified the name of the Postgres Database Owner"
+  type        = string
+  default     = null
+}
+
+variable "database_names" {
+  description = "List of database names to create. If empty, defaults to a single database named after the instance."
+  type        = set(string)
+  default     = []
+}
+
+variable "user_names" {
+  description = "List of additional database users to create. Elements must be unique."
+  type        = set(string)
+  default     = []
+}
+
 variable "project_id" {
   description = "The ID of the STACKIT project where the database will be created."
   type        = string
@@ -72,4 +90,10 @@ variable "kubernetes_namespace" {
   description = "Kubernetes namespace where the External Secret manifest will be applied."
   type        = string
   default     = "[your-namespace]"
+}
+
+variable "manifest_filename" {
+  description = "Kubernetes namespace where the External Secret manifest will be applied."
+  type        = string
+  default     = null
 }

--- a/stackit-postgres-db/variables.tf
+++ b/stackit-postgres-db/variables.tf
@@ -92,8 +92,14 @@ variable "kubernetes_namespace" {
   default     = "[your-namespace]"
 }
 
-variable "manifest_filename" {
-  description = "Kubernetes namespace where the External Secret manifest will be applied."
+variable "external_secret_manifest" {
+  description = "Path where the external secret manifest will be stored at"
+  type        = string
+  default     = null
+}
+
+variable "config_map_manifest" {
+  description = "Path where the config map manifest will be stored at"
   type        = string
   default     = null
 }


### PR DESCRIPTION
This PR changes the `stackit-postgres-db` module in the following ways:

- allows the creation of multiple databases with different names than the instance
- allows the creation of a root user with a different name than the instance
- allows the creation of multiple additional users with Login Permission
- creates a local_file resource for the manifest if secrets are managed
- Test and Readme adjustments