### PR TITLE
Fix configMap data values to be strings and not an object

### DIFF
--- a/stackit-postgres-db/main.tf
+++ b/stackit-postgres-db/main.tf
@@ -158,11 +158,9 @@ resource "local_file" "config_map_manifest" {
         namespace = var.kubernetes_namespace
       }
       data = {
-        database = {
-          database = db_name
-          host     = stackit_postgresflex_user.admin.host
-          port     = tostring(stackit_postgresflex_user.admin.port)
-        }
+        "database.name" = db_name
+        "database.host" = stackit_postgresflex_user.admin.host
+        "database.port" = tostring(stackit_postgresflex_user.admin.port)
       }
     })
   ]))


### PR DESCRIPTION
The values for the `data` property of a K8s ConfigMap must be strings and not an object, thus the attributes are flattened.

Also `database.database` is renamed to `database.name` as that is the proper attribute for it.