### PR TITLE
Use local_file resource for manifest instead of output

### DIFF
--- a/stackit-object-storage/.terraform.lock.hcl
+++ b/stackit-object-storage/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.6.1"
+  hashes = [
+    "h1:DbiR/D2CPigzCGweYIyJH0N0x04oyI5xiZ9wSW/s3kQ=",
+    "zh:10050d08f416de42a857e4b6f76809aae63ea4ec6f5c852a126a915dede814b4",
+    "zh:2df2a3ebe9830d4759c59b51702e209fe053f47453cb4688f43c063bac8746b7",
+    "zh:2e759568bcc38c86ca0e43701d34cf29945736fdc8e429c5b287ddc2703c7b18",
+    "zh:6a62a34e48500ab4aea778e355e162ebde03260b7a9eb9edc7e534c84fbca4c6",
+    "zh:74373728ba32a1d5450a3a88ac45624579e32755b086cd4e51e88d9aca240ef6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8dddae588971a996f622e7589cd8b9da7834c744ac12bfb59c97fa77ded95255",
+    "zh:946f82f66353bb97aefa8d95c4ca86db227f9b7c50b82415289ac47e4e74d08d",
+    "zh:e9a5c09e6f35e510acf15b666fd0b34a30164cecdcd81ce7cda0f4b2dade8d91",
+    "zh:eafe5b873ef42b32feb2f969c38ff8652507e695620cbaf03b9db714bee52249",
+    "zh:ec146289fa27650c9d433bb5c7847379180c0b7a323b1b94e6e7ad5d2a7dbe71",
+    "zh:fc882c35ce05631d76c0973b35adde26980778fc81d9da81a2fade2b9d73423b",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/vault" {
   version     = "5.6.0"
   constraints = ">= 5.3.0"

--- a/stackit-object-storage/README.md
+++ b/stackit-object-storage/README.md
@@ -15,19 +15,8 @@ module "object_storage_bucket" {
 
   manage_credentials         = true
   secret_manager_instance_id = "[instance id of your secrets manager (can be referenced from the stackit-secrets-manager module)]"
-}
-
-
-# Write the External Secret manifest to a file, null_resources will only be executed once, so you can keep them.
-# Please adjust the path to your kustomize overlay accordingly.
-resource "null_resource" "external_secret" {
-  provisioner "local-exec" {
-    command = <<-EOT
-cat <<EOF > ../path/to/overlay/external-secret-manifest.yaml
-${module.object_storage_bucket.external_secret_manifest}
-EOF
-    EOT
-  }
+  kubernetes_namespace       = "[your-namespace]" # Namespace where the External Secret manifest will be applied
+  external_secret_manifest   = "[path-to-the-manifest-file-to-be-created]" # The path in your system the external secret manifest will be stored at
 }
 ```
 
@@ -47,6 +36,7 @@ module "object_storage_bucket" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >1.10.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >=2.6.1 |
 | <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >=0.65.0 |
 | <a name="requirement_vault"></a> [vault](#requirement\_vault) | >=5.3.0 |
 
@@ -54,6 +44,7 @@ module "object_storage_bucket" {
 
 | Name | Version |
 |------|---------|
+| <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
 | <a name="provider_stackit"></a> [stackit](#provider\_stackit) | 0.68.0 |
 | <a name="provider_vault"></a> [vault](#provider\_vault) | 5.6.0 |
 
@@ -61,6 +52,7 @@ module "object_storage_bucket" {
 
 | Name | Type |
 |------|------|
+| [local_file.external_secret_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [stackit_objectstorage_bucket.bucket](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket) | resource |
 | [stackit_objectstorage_credential.credential](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
 | [stackit_objectstorage_credentials_group.credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
@@ -72,7 +64,8 @@ module "object_storage_bucket" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the bucket. | `string` | n/a | yes |
 | <a name="input_credentials_names"></a> [credentials\_names](#input\_credentials\_names) | Names of credentials to create for the bucket. Defaults to ['default']. | `list(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
-| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `"[your-namespace]"` | no |
+| <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest) | Path where the external secret manifest will be stored at | `string` | `null` | no |
+| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `null` | no |
 | <a name="input_manage_credentials"></a> [manage\_credentials](#input\_manage\_credentials) | Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]` | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where the bucket will be created. | `string` | n/a | yes |
 | <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id) | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_credentials is true. | `string` | `null` | no |
@@ -83,5 +76,4 @@ module "object_storage_bucket" {
 |------|-------------|
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
 | <a name="output_credentials"></a> [credentials](#output\_credentials) | Credentials to access the S3 bucket. Only available if `manage_credentials` is false |
-| <a name="output_external_secret_manifest"></a> [external\_secret\_manifest](#output\_external\_secret\_manifest) | Kubernetes External Secret manifest to fetch the bucket credentials from STACKIT Secrets Manager. Only available if `manage_credentials` is true. |
 <!-- END_TF_DOCS -->

--- a/stackit-object-storage/main.tf
+++ b/stackit-object-storage/main.tf
@@ -1,3 +1,12 @@
+locals {
+  yaml_autocreate_warning = <<-EOT
+    ###
+    # DO NOT EDIT MANUALLY
+    # THIS FILE IS MANAGED BY TERRAFORM
+    ###
+  EOT
+}
+
 resource "stackit_objectstorage_bucket" "bucket" {
   project_id = var.project_id
   name       = var.bucket_name
@@ -26,4 +35,53 @@ resource "vault_kv_secret_v2" "bucket_credentials" {
     access_key        = stackit_objectstorage_credential.credential[each.key].access_key
     secret_access_key = stackit_objectstorage_credential.credential[each.key].secret_access_key
   })
+}
+
+resource "local_file" "external_secret_manifest" {
+  count = var.manage_credentials ? 1 : 0
+
+  lifecycle {
+    precondition {
+      # Only create the file if manage_credentials is set (otherwise the resource would not be created at all)
+      # and error out if the filename was not provided.
+      condition     = var.external_secret_manifest != null && var.kubernetes_namespace != null
+      error_message = "You enabled 'manage_credentials' but did not provide 'external_secret_manifest' and 'kubernetes_namespace'."
+    }
+  }
+
+  filename = var.external_secret_manifest
+
+  content = format("%s%s", local.yaml_autocreate_warning, join("\n---\n", [
+    for name in var.credentials_names : yamlencode({
+      apiVersion = "external-secrets.io/v1"
+      kind       = "ExternalSecret"
+      metadata = {
+        name      = "${var.bucket_name}-bucket-credentials-${name}"
+        namespace = var.kubernetes_namespace
+      }
+      spec = {
+        refreshInterval = "15m"
+        secretStoreRef = {
+          name = "secret-store"
+          kind = "SecretStore"
+        }
+        data = [
+          {
+            secretKey = "access_key"
+            remoteRef = {
+              key      = "object-storage/${stackit_objectstorage_bucket.bucket.name}/${name}"
+              property = "access_key"
+            }
+          },
+          {
+            secretKey = "secret_access_key"
+            remoteRef = {
+              key      = "object-storage/${stackit_objectstorage_bucket.bucket.name}/${name}"
+              property = "secret_access_key"
+            }
+          }
+        ]
+      }
+    })
+  ]))
 }

--- a/stackit-object-storage/outputs.tf
+++ b/stackit-object-storage/outputs.tf
@@ -12,37 +12,3 @@ output "credentials" {
 output "bucket_name" {
   value = stackit_objectstorage_bucket.bucket.name
 }
-
-locals {
-  manifest_list = [
-    for name in var.credentials_names : <<EOF
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: bucket-credentials-${name}
-  namespace: ${var.kubernetes_namespace}
-spec:
-  refreshInterval: "15m"
-  secretStoreRef:
-    name: secret-store
-    kind: SecretStore
-  target:
-    name: bucket-credentials-${name}
-  data:
-    - secretKey: access_key
-      remoteRef:
-        key: object-storage/${stackit_objectstorage_bucket.bucket.name}/${name}
-        property: access_key
-    - secretKey: secret_access_key
-      remoteRef:
-        key: object-storage/${stackit_objectstorage_bucket.bucket.name}/${name}
-        property: secret_access_key
-EOF
-  ]
-  external_secrets_manifest = var.manage_credentials ? join("\n---\n", local.manifest_list) : ""
-}
-
-output "external_secret_manifest" {
-  description = "Kubernetes External Secret manifest to fetch the bucket credentials from STACKIT Secrets Manager. Only available if `manage_credentials` is true."
-  value       = var.manage_credentials ? local.external_secrets_manifest : ""
-}

--- a/stackit-object-storage/terraform.tf
+++ b/stackit-object-storage/terraform.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = ">1.10.0"
 
   required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = ">=2.6.1"
+    }
     stackit = {
       source  = "stackitcloud/stackit"
       version = ">=0.65.0"

--- a/stackit-object-storage/variables.tf
+++ b/stackit-object-storage/variables.tf
@@ -34,5 +34,11 @@ variable "secret_manager_instance_id" {
 variable "kubernetes_namespace" {
   description = "Kubernetes namespace where the External Secret manifest will be applied."
   type        = string
-  default     = "[your-namespace]"
+  default     = null
+}
+
+variable "external_secret_manifest" {
+  description = "Path where the external secret manifest will be stored at"
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
- uses a local file resource for the generated secrets manifest
- prefixes the metadata.name value with the bucket name for the generated secret, so that you can have multiple of those in your K8s namespace
