### PR TITLE
feat(stackit-object-storage): Implement IAM policies for credential access control

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -23,7 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform_module: ["stackit-object-storage", "stackit-state-bucket", "stackit-secrets-manager", "stackit-postgres-db"]
+        terraform_module:
+          [
+            "stackit-object-storage",
+            "stackit-state-bucket",
+            "stackit-secrets-manager",
+            "stackit-postgres-db",
+          ]
     steps:
       - uses: actions/checkout@v5
       - name: "Install Terraform CLI"
@@ -47,7 +53,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform_module: ["stackit-object-storage", "stackit-state-bucket", "stackit-secrets-manager", "stackit-postgres-db"]
+        terraform_module:
+          [
+            "stackit-object-storage",
+            "stackit-state-bucket",
+            "stackit-secrets-manager",
+            "stackit-postgres-db",
+          ]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This repository contains a collection of Terraform modules we use in our infrast
 
 When developing modules for the OpenTelekomCloud, this repository can serve as useful inspiration: https://github.com/iits-consulting/terraform-opentelekomcloud-project-factory/tree/master/modules
 
-
 # terraform-docs
 
 When developing our modules for STACKIT, please ensure to also use `terraform-docs` to autogenerate additional documentation for each module.

--- a/stackit-object-storage/.terraform.lock.hcl
+++ b/stackit-object-storage/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.28.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:RwoFuX1yGMVaKJaUmXDKklEaQ/yUCEdt5k2kz+/g08c=",
+    "zh:0ba0d5eb6e0c6a933eb2befe3cdbf22b58fbc0337bf138f95bf0e8bb6e6df93e",
+    "zh:23eacdd4e6db32cf0ff2ce189461bdbb62e46513978d33c5de4decc4670870ec",
+    "zh:307b06a15fc00a8e6fd243abde2cbe5112e9d40371542665b91bec1018dd6e3c",
+    "zh:37a02d5b45a9d050b9642c9e2e268297254192280df72f6e46641daca52e40ec",
+    "zh:3da866639f07d92e734557d673092719c33ede80f4276c835bf7f231a669aa33",
+    "zh:480060b0ba310d0f6b6a14d60b276698cb103c48fd2f7e2802ae47c963995ec6",
+    "zh:57796453455c20db80d9168edbf125bf6180e1aae869de1546a2be58e4e405ec",
+    "zh:69139cba772d4df8de87598d8d8a2b1b4b254866db046c061dccc79edb14e6b9",
+    "zh:7312763259b859ff911c5452ca8bdf7d0be6231c5ea0de2df8f09d51770900ac",
+    "zh:8d2d6f4015d3c155d7eb53e36f019a729aefb46ebfe13f3a637327d3a1402ecc",
+    "zh:94ce589275c77308e6253f607de96919b840c2dd36c44aa798f693c9dd81af42",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:adaceec6a1bf4f5df1e12bd72cf52b72087c72efed078aef636f8988325b1a8b",
+    "zh:d37be1ce187d94fd9df7b13a717c219964cd835c946243f096c6b230cdfd7e92",
+    "zh:fe6205b5ca2ff36e68395cb8d3ae10a3728f405cdbcd46b206a515e1ebcf17a1",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.6.1"
   hashes = [

--- a/stackit-object-storage/README.md
+++ b/stackit-object-storage/README.md
@@ -7,17 +7,42 @@ with the
 By default, two credentials are created:
 
 - `default` with `superuser` role to be used by your application
-- `terraform` with `superuser` role to be used by terraform to manage the bucket
+- `terraform` with a role to be used by terraform to manage the bucket. This role does not have access to the content of
+  the bucket.
+
+> 💡 In case you already have another bucket in your terraform configuration, you should provide the
+`terraform_credentials_group_id` input variable to let terraform manage the bucket with the existing credentials group.
 
 ## Usage
+
+### AWS Provider Configuration
+
+To manage access policies on the bucket, you need to configure the `aws` provider:
+
+```hcl
+provider "aws" {
+  region                      = "eu01"
+  skip_credentials_validation = true
+  skip_region_validation      = true
+  skip_requesting_account_id = true
+
+  # You can also use credentials from another object storage module
+  access_key = module.backend_bucket.access_key
+  secret_key = module.backend_bucket.secret_access_key
+
+  endpoints {
+    s3 = "https://object.storage.eu01.onstackit.cloud"
+  }
+}
+```
 
 ### With STACKIT Secrets Manager
 
 ```hcl
 module "object_storage_bucket" {
-  source      = "github.com/digitalservicebund/terraform-modules//stackit-object-storage?ref=[sha of the commit you want to use]"
-  project_id  = "[stackit project id]"
-  bucket_name = "[my-bucket-name]"
+  source                         = "github.com/digitalservicebund/terraform-modules//stackit-object-storage?ref=[sha of the commit you want to use]"
+  project_id                     = "[stackit project id]"
+  bucket_name                    = "[my-bucket-name]"
   terraform_credentials_group_id = "[credentials group id used by terraform to manage the bucket (can be referenced from the stackit-state-bucket module)]"
 
   manage_credentials         = true
@@ -32,9 +57,9 @@ module "object_storage_bucket" {
 
 ```hcl
 module "object_storage_bucket" {
-  source      = "github.com/digitalservicebund/terraform-modules//stackit-object-storage?ref=[sha of the commit you want to use]"
-  project_id  = "[stackit project id]"
-  bucket_name = "[my-bucket-name]"
+  source                         = "github.com/digitalservicebund/terraform-modules//stackit-object-storage?ref=[sha of the commit you want to use]"
+  project_id                     = "[stackit project id]"
+  bucket_name                    = "[my-bucket-name]"
   terraform_credentials_group_id = "[credentials group id used by terraform to manage the bucket (can be referenced from the stackit-state-bucket module)]"
 }
 ```
@@ -64,62 +89,64 @@ module "object_storage_bucket" {
 ```  
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >1.10.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=6.28.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | >=2.6.1 |
-| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >=0.65.0 |
-| <a name="requirement_vault"></a> [vault](#requirement\_vault) | >=5.3.0 |
+| Name                                                                      | Version  |
+|---------------------------------------------------------------------------|----------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >1.10.0  |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >=6.28.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local)             | >=2.6.1  |
+| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit)       | >=0.65.0 |
+| <a name="requirement_vault"></a> [vault](#requirement\_vault)             | >=5.3.0  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.28.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
-| <a name="provider_stackit"></a> [stackit](#provider\_stackit) | 0.68.0 |
-| <a name="provider_vault"></a> [vault](#provider\_vault) | 5.6.0 |
+| Name                                                          | Version |
+|---------------------------------------------------------------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws)             | 6.28.0  |
+| <a name="provider_local"></a> [local](#provider\_local)       | 2.6.1   |
+| <a name="provider_stackit"></a> [stackit](#provider\_stackit) | 0.68.0  |
+| <a name="provider_vault"></a> [vault](#provider\_vault)       | 5.6.0   |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [local_file.external_secret_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [stackit_objectstorage_bucket.bucket](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket) | resource |
-| [stackit_objectstorage_credential.credential](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
-| [stackit_objectstorage_credential.terraform_credentials](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
-| [stackit_objectstorage_credentials_group.terraform_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
-| [stackit_objectstorage_credentials_group.user_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
-| [vault_kv_secret_v2.bucket_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
-| [aws_iam_policy_document.combined_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.disable_access_for_other_credentials_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| Name                                                                                                                                                                                                  | Type        |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy)                                                                    | resource    |
+| [local_file.external_secret_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file)                                                                             | resource    |
+| [stackit_objectstorage_bucket.bucket](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket)                                                        | resource    |
+| [stackit_objectstorage_credential.credential](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential)                                            | resource    |
+| [stackit_objectstorage_credential.terraform_credentials](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential)                                 | resource    |
+| [stackit_objectstorage_credentials_group.terraform_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group)             | resource    |
+| [stackit_objectstorage_credentials_group.user_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group)                  | resource    |
+| [vault_kv_secret_v2.bucket_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2)                                                                   | resource    |
+| [aws_iam_policy_document.combined_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                         | data source |
+| [aws_iam_policy_document.disable_access_for_other_credentials_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                             | data source |
+| [aws_iam_policy_document.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                               | data source |
+| [aws_iam_policy_document.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                              | data source |
 | [stackit_objectstorage_credentials_group.existing_terraform_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/objectstorage_credentials_group) | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the bucket. | `string` | n/a | yes |
-| <a name="input_credentials"></a> [credentials](#input\_credentials) | Credentials to create for the bucket. Map of credential name to role. Valid roles are: superuser, read-only, read-write. | `map(string)` | <pre>{<br/>  "default": "superuser"<br/>}</pre> | no |
-| <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest) | Path where the external secret manifest will be stored at | `string` | `null` | no |
-| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `null` | no |
-| <a name="input_manage_credentials"></a> [manage\_credentials](#input\_manage\_credentials) | Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]` | `bool` | `false` | no |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where the bucket will be created. | `string` | n/a | yes |
-| <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id) | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_credentials is true. | `string` | `null` | no |
-| <a name="input_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#input\_terraform\_credentials\_group\_id) | ID of the credentials group that is used by Terraform to manage the bucket. If not provided, a new credentials group will be created. | `string` | n/a | yes |
+| Name                                                                                                                               | Description                                                                                                                                   | Type          | Default                                         | Required |
+|------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------|:--------:|
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name)                                                              | The name of the bucket.                                                                                                                       | `string`      | n/a                                             |   yes    |
+| <a name="input_credentials"></a> [credentials](#input\_credentials)                                                                | Credentials to create for the bucket. Map of credential name to role. Valid roles are: superuser, read-only, read-write.                      | `map(string)` | <pre>{<br/>  "default": "superuser"<br/>}</pre> |    no    |
+| <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest)                     | Path where the external secret manifest will be stored at                                                                                     | `string`      | `null`                                          |    no    |
+| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace)                                   | Kubernetes namespace where the External Secret manifest will be applied.                                                                      | `string`      | `null`                                          |    no    |
+| <a name="input_manage_credentials"></a> [manage\_credentials](#input\_manage\_credentials)                                         | Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]` | `bool`        | `false`                                         |    no    |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id)                                                                 | The ID of the project where the bucket will be created.                                                                                       | `string`      | n/a                                             |   yes    |
+| <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id)             | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_credentials is true.                 | `string`      | `null`                                          |    no    |
+| <a name="input_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#input\_terraform\_credentials\_group\_id) | ID of the credentials group that is used by Terraform to manage the bucket. If not provided, a new credentials group will be created.         | `string`      | n/a                                             |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
-| <a name="output_credentials"></a> [credentials](#output\_credentials) | Credentials to access the S3 bucket. Only available if `manage_credentials` is false |
-| <a name="output_terraform_credentials"></a> [terraform\_credentials](#output\_terraform\_credentials) | Credentials to manage S3 bucket via Terraform. This will be empty if `terraform_credentails_group_id` is provided. |
-| <a name="output_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#output\_terraform\_credentials\_group\_id) | The ID of the credentials group used by Terraform to manage the S3 bucket. |
+| Name                                                                                                                                 | Description                                                                                                        |
+|--------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name)                                                              | n/a                                                                                                                |
+| <a name="output_credentials"></a> [credentials](#output\_credentials)                                                                | Credentials to access the S3 bucket. Only available if `manage_credentials` is false                               |
+| <a name="output_terraform_credentials"></a> [terraform\_credentials](#output\_terraform\_credentials)                                | Credentials to manage S3 bucket via Terraform. This will be empty if `terraform_credentails_group_id` is provided. |
+| <a name="output_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#output\_terraform\_credentials\_group\_id) | The ID of the credentials group used by Terraform to manage the S3 bucket.                                         |
+
 <!-- END_TF_DOCS -->

--- a/stackit-object-storage/README.md
+++ b/stackit-object-storage/README.md
@@ -18,6 +18,7 @@ module "object_storage_bucket" {
   source      = "github.com/digitalservicebund/terraform-modules//stackit-object-storage?ref=[sha of the commit you want to use]"
   project_id  = "[stackit project id]"
   bucket_name = "[my-bucket-name]"
+  terraform_credentials_group_id = "[credentials group id used by terraform to manage the bucket (can be referenced from the stackit-state-bucket module)]"
 
   manage_credentials         = true
   secret_manager_instance_id = "[instance id of your secrets manager (can be referenced from the stackit-secrets-manager module)]"
@@ -34,6 +35,7 @@ module "object_storage_bucket" {
   source      = "github.com/digitalservicebund/terraform-modules//stackit-object-storage?ref=[sha of the commit you want to use]"
   project_id  = "[stackit project id]"
   bucket_name = "[my-bucket-name]"
+  terraform_credentials_group_id = "[credentials group id used by terraform to manage the bucket (can be referenced from the stackit-state-bucket module)]"
 }
 ```
 
@@ -46,15 +48,17 @@ For example, to create two read-only credentials in addition to the default supe
 
 ```hcl
 module "object_storage_bucket" {
-  source      = "github.com/digitalservicebund/terraform-modules//stackit-object-storage?ref=[sha of the commit you want to use]"
-  project_id  = "[stackit project id]"
-  bucket_name = "[my-bucket-name]"
-  
+  source                         = "github.com/digitalservicebund/terraform-modules//stackit-object-storage?ref=[sha of the commit you want to use]"
+  project_id                     = "[stackit project id]"
+  bucket_name                    = "[my-bucket-name]"
+  terraform_credentials_group_id = "[credentials group id used by terraform to manage the bucket (can be referenced from the stackit-state-bucket module)]"
+
+
   credentials = {
     # <name> = <role>
-    default  = "superuser"
-    team1 = "read-only"
-    team2 = "read-only"
+    default = "superuser"
+    team1   = "read-only"
+    team2   = "read-only"
   }
 }
 ```  
@@ -95,6 +99,7 @@ module "object_storage_bucket" {
 | [aws_iam_policy_document.disable_access_for_other_credentials_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [stackit_objectstorage_credentials_group.existing_terraform_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/objectstorage_credentials_group) | data source |
 
 ## Inputs
 
@@ -107,6 +112,7 @@ module "object_storage_bucket" {
 | <a name="input_manage_credentials"></a> [manage\_credentials](#input\_manage\_credentials) | Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]` | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where the bucket will be created. | `string` | n/a | yes |
 | <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id) | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_credentials is true. | `string` | `null` | no |
+| <a name="input_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#input\_terraform\_credentials\_group\_id) | ID of the credentials group that is used by Terraform to manage the bucket. If not provided, a new credentials group will be created. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -114,5 +120,6 @@ module "object_storage_bucket" {
 |------|-------------|
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
 | <a name="output_credentials"></a> [credentials](#output\_credentials) | Credentials to access the S3 bucket. Only available if `manage_credentials` is false |
-| <a name="output_terraform_credentials"></a> [terraform\_credentials](#output\_terraform\_credentials) | Credentials to manage S3 bucket via Terraform |
+| <a name="output_terraform_credentials"></a> [terraform\_credentials](#output\_terraform\_credentials) | Credentials to manage S3 bucket via Terraform. This will be empty if `terraform_credentails_group_id` is provided. |
+| <a name="output_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#output\_terraform\_credentials\_group\_id) | The ID of the credentials group used by Terraform to manage the S3 bucket. |
 <!-- END_TF_DOCS -->

--- a/stackit-object-storage/README.md
+++ b/stackit-object-storage/README.md
@@ -26,7 +26,6 @@ provider "aws" {
   skip_region_validation      = true
   skip_requesting_account_id = true
 
-  # You can also use credentials from another object storage module
   access_key = module.backend_bucket.access_key
   secret_key = module.backend_bucket.secret_access_key
 

--- a/stackit-object-storage/README.md
+++ b/stackit-object-storage/README.md
@@ -36,6 +36,7 @@ module "object_storage_bucket" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >1.10.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=6.28.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >=2.6.1 |
 | <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >=0.65.0 |
 | <a name="requirement_vault"></a> [vault](#requirement\_vault) | >=5.3.0 |
@@ -44,6 +45,7 @@ module "object_storage_bucket" {
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.28.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
 | <a name="provider_stackit"></a> [stackit](#provider\_stackit) | 0.68.0 |
 | <a name="provider_vault"></a> [vault](#provider\_vault) | 5.6.0 |
@@ -52,18 +54,25 @@ module "object_storage_bucket" {
 
 | Name | Type |
 |------|------|
+| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [local_file.external_secret_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [stackit_objectstorage_bucket.bucket](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket) | resource |
 | [stackit_objectstorage_credential.credential](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
+| [stackit_objectstorage_credential.terraform_credentials](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
 | [stackit_objectstorage_credentials_group.credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
+| [stackit_objectstorage_credentials_group.terraform_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
 | [vault_kv_secret_v2.bucket_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
+| [aws_iam_policy_document.combined_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.disable_access_for_other_credentials_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the bucket. | `string` | n/a | yes |
-| <a name="input_credentials_names"></a> [credentials\_names](#input\_credentials\_names) | Names of credentials to create for the bucket. Defaults to ['default']. | `list(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
+| <a name="input_credentials"></a> [credentials](#input\_credentials) | Credentials to create for the bucket. Map of credential name to role. Valid roles are: superuser, read-only, read-write. | `map(string)` | <pre>{<br/>  "default": "superuser"<br/>}</pre> | no |
 | <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest) | Path where the external secret manifest will be stored at | `string` | `null` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `null` | no |
 | <a name="input_manage_credentials"></a> [manage\_credentials](#input\_manage\_credentials) | Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]` | `bool` | `false` | no |
@@ -76,4 +85,5 @@ module "object_storage_bucket" {
 |------|-------------|
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
 | <a name="output_credentials"></a> [credentials](#output\_credentials) | Credentials to access the S3 bucket. Only available if `manage_credentials` is false |
+| <a name="output_terraform_credentials"></a> [terraform\_credentials](#output\_terraform\_credentials) | Credentials to manage S3 bucket via Terraform |
 <!-- END_TF_DOCS -->

--- a/stackit-object-storage/README.md
+++ b/stackit-object-storage/README.md
@@ -89,64 +89,62 @@ module "object_storage_bucket" {
 ```  
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                      | Version  |
-|---------------------------------------------------------------------------|----------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >1.10.0  |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >=6.28.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local)             | >=2.6.1  |
-| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit)       | >=0.65.0 |
-| <a name="requirement_vault"></a> [vault](#requirement\_vault)             | >=5.3.0  |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >1.10.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=6.28.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >=2.6.1 |
+| <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >=0.65.0 |
+| <a name="requirement_vault"></a> [vault](#requirement\_vault) | >=5.3.0 |
 
 ## Providers
 
-| Name                                                          | Version |
-|---------------------------------------------------------------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws)             | 6.28.0  |
-| <a name="provider_local"></a> [local](#provider\_local)       | 2.6.1   |
-| <a name="provider_stackit"></a> [stackit](#provider\_stackit) | 0.68.0  |
-| <a name="provider_vault"></a> [vault](#provider\_vault)       | 5.6.0   |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.28.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.6.1 |
+| <a name="provider_stackit"></a> [stackit](#provider\_stackit) | 0.68.0 |
+| <a name="provider_vault"></a> [vault](#provider\_vault) | 5.6.0 |
 
 ## Resources
 
-| Name                                                                                                                                                                                                  | Type        |
-|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy)                                                                    | resource    |
-| [local_file.external_secret_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file)                                                                             | resource    |
-| [stackit_objectstorage_bucket.bucket](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket)                                                        | resource    |
-| [stackit_objectstorage_credential.credential](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential)                                            | resource    |
-| [stackit_objectstorage_credential.terraform_credentials](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential)                                 | resource    |
-| [stackit_objectstorage_credentials_group.terraform_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group)             | resource    |
-| [stackit_objectstorage_credentials_group.user_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group)                  | resource    |
-| [vault_kv_secret_v2.bucket_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2)                                                                   | resource    |
-| [aws_iam_policy_document.combined_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                         | data source |
-| [aws_iam_policy_document.disable_access_for_other_credentials_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                             | data source |
-| [aws_iam_policy_document.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                               | data source |
-| [aws_iam_policy_document.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)                                                              | data source |
+| Name | Type |
+|------|------|
+| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [local_file.external_secret_manifest](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [stackit_objectstorage_bucket.bucket](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket) | resource |
+| [stackit_objectstorage_credential.credential](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
+| [stackit_objectstorage_credential.terraform_credentials](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
+| [stackit_objectstorage_credentials_group.terraform_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
+| [stackit_objectstorage_credentials_group.user_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
+| [vault_kv_secret_v2.bucket_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
+| [aws_iam_policy_document.combined_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.disable_access_for_other_credentials_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [stackit_objectstorage_credentials_group.existing_terraform_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/objectstorage_credentials_group) | data source |
 
 ## Inputs
 
-| Name                                                                                                                               | Description                                                                                                                                   | Type          | Default                                         | Required |
-|------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------|:--------:|
-| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name)                                                              | The name of the bucket.                                                                                                                       | `string`      | n/a                                             |   yes    |
-| <a name="input_credentials"></a> [credentials](#input\_credentials)                                                                | Credentials to create for the bucket. Map of credential name to role. Valid roles are: superuser, read-only, read-write.                      | `map(string)` | <pre>{<br/>  "default": "superuser"<br/>}</pre> |    no    |
-| <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest)                     | Path where the external secret manifest will be stored at                                                                                     | `string`      | `null`                                          |    no    |
-| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace)                                   | Kubernetes namespace where the External Secret manifest will be applied.                                                                      | `string`      | `null`                                          |    no    |
-| <a name="input_manage_credentials"></a> [manage\_credentials](#input\_manage\_credentials)                                         | Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]` | `bool`        | `false`                                         |    no    |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id)                                                                 | The ID of the project where the bucket will be created.                                                                                       | `string`      | n/a                                             |   yes    |
-| <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id)             | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_credentials is true.                 | `string`      | `null`                                          |    no    |
-| <a name="input_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#input\_terraform\_credentials\_group\_id) | ID of the credentials group that is used by Terraform to manage the bucket. If not provided, a new credentials group will be created.         | `string`      | n/a                                             |   yes    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the bucket. | `string` | n/a | yes |
+| <a name="input_credentials"></a> [credentials](#input\_credentials) | Credentials to create for the bucket. Map of credential name to role. Valid roles are: superuser, read-only, read-write. | `map(string)` | <pre>{<br/>  "default": "superuser"<br/>}</pre> | no |
+| <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest) | Path where the external secret manifest will be stored at | `string` | `null` | no |
+| <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `null` | no |
+| <a name="input_manage_credentials"></a> [manage\_credentials](#input\_manage\_credentials) | Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]` | `bool` | `false` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where the bucket will be created. | `string` | n/a | yes |
+| <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id) | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_credentials is true. | `string` | `null` | no |
+| <a name="input_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#input\_terraform\_credentials\_group\_id) | ID of the credentials group that is used by Terraform to manage the bucket. If not provided, a new credentials group will be created. | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                                                                                                                                 | Description                                                                                                        |
-|--------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name)                                                              | n/a                                                                                                                |
-| <a name="output_credentials"></a> [credentials](#output\_credentials)                                                                | Credentials to access the S3 bucket. Only available if `manage_credentials` is false                               |
-| <a name="output_terraform_credentials"></a> [terraform\_credentials](#output\_terraform\_credentials)                                | Credentials to manage S3 bucket via Terraform. This will be empty if `terraform_credentails_group_id` is provided. |
-| <a name="output_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#output\_terraform\_credentials\_group\_id) | The ID of the credentials group used by Terraform to manage the S3 bucket.                                         |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
+| <a name="output_credentials"></a> [credentials](#output\_credentials) | Credentials to access the S3 bucket. Only available if `manage_credentials` is false |
+| <a name="output_terraform_credentials"></a> [terraform\_credentials](#output\_terraform\_credentials) | Credentials to manage S3 bucket via Terraform. This will be empty if `terraform_credentails_group_id` is provided. |
+| <a name="output_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#output\_terraform\_credentials\_group\_id) | The ID of the credentials group used by Terraform to manage the S3 bucket. |
 <!-- END_TF_DOCS -->

--- a/stackit-object-storage/README.md
+++ b/stackit-object-storage/README.md
@@ -1,11 +1,17 @@
 # StackIT Object Storage Module
 
-This module creates a STACKIT object storage bucket and credentials to access it. Its recommended to use it together with the
+This module creates a STACKIT object storage bucket and credentials to access it. It is recommended to use it together
+with the
 [STACKIT Secrets Manager Module](../stackit-secrets-manager) to store the credentials securely.
+
+By default, two credentials are created:
+
+- `default` with `superuser` role to be used by your application
+- `terraform` with `superuser` role to be used by terraform to manage the bucket
 
 ## Usage
 
-With STACKIT Secrets Manager
+### With STACKIT Secrets Manager
 
 ```hcl
 module "object_storage_bucket" {
@@ -15,12 +21,13 @@ module "object_storage_bucket" {
 
   manage_credentials         = true
   secret_manager_instance_id = "[instance id of your secrets manager (can be referenced from the stackit-secrets-manager module)]"
-  kubernetes_namespace       = "[your-namespace]" # Namespace where the External Secret manifest will be applied
-  external_secret_manifest   = "[path-to-the-manifest-file-to-be-created]" # The path in your system the external secret manifest will be stored at
+  kubernetes_namespace = "[your-namespace]" # Namespace where the External Secret manifest will be applied
+  external_secret_manifest   = "[path-to-the-manifest-file-to-be-created]"
+  # The path in your system the external secret manifest will be stored at
 }
 ```
 
-Without STACKIT Secrets Manager
+### Without STACKIT Secrets Manager
 
 ```hcl
 module "object_storage_bucket" {
@@ -29,6 +36,28 @@ module "object_storage_bucket" {
   bucket_name = "[my-bucket-name]"
 }
 ```
+
+### Generating multiple credentials
+
+The module supports the generation of multiple credentials with different roles. You can specify the credentials to be
+created using the `credentials` input variable.
+
+For example, to create two read-only credentials in addition to the default superuser credential:
+
+```hcl
+module "object_storage_bucket" {
+  source      = "github.com/digitalservicebund/terraform-modules//stackit-object-storage?ref=[sha of the commit you want to use]"
+  project_id  = "[stackit project id]"
+  bucket_name = "[my-bucket-name]"
+  
+  credentials = {
+    # <name> = <role>
+    default  = "superuser"
+    team1 = "read-only"
+    team2 = "read-only"
+  }
+}
+```  
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -59,8 +88,8 @@ module "object_storage_bucket" {
 | [stackit_objectstorage_bucket.bucket](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket) | resource |
 | [stackit_objectstorage_credential.credential](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
 | [stackit_objectstorage_credential.terraform_credentials](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credential) | resource |
-| [stackit_objectstorage_credentials_group.credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
 | [stackit_objectstorage_credentials_group.terraform_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
+| [stackit_objectstorage_credentials_group.user_credentials_group](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_credentials_group) | resource |
 | [vault_kv_secret_v2.bucket_credentials](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
 | [aws_iam_policy_document.combined_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.disable_access_for_other_credentials_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/stackit-object-storage/README.md
+++ b/stackit-object-storage/README.md
@@ -130,13 +130,13 @@ module "object_storage_bucket" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the bucket. | `string` | n/a | yes |
-| <a name="input_credentials"></a> [credentials](#input\_credentials) | Credentials to create for the bucket. Map of credential name to role. Valid roles are: superuser, read-only, read-write. | `map(string)` | <pre>{<br/>  "default": "superuser"<br/>}</pre> | no |
+| <a name="input_credentials"></a> [credentials](#input\_credentials) | Credentials to create for the bucket. Map of credential name to role (e.g. { name = role }. Valid roles are: superuser, read-only, read-write. | `map(string)` | <pre>{<br/>  "default": "superuser"<br/>}</pre> | no |
 | <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest) | Path where the external secret manifest will be stored at | `string` | `null` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `null` | no |
 | <a name="input_manage_credentials"></a> [manage\_credentials](#input\_manage\_credentials) | Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]` | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where the bucket will be created. | `string` | n/a | yes |
 | <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id) | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_credentials is true. | `string` | `null` | no |
-| <a name="input_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#input\_terraform\_credentials\_group\_id) | ID of the credentials group that is used by Terraform to manage the bucket. If not provided, a new credentials group will be created. | `string` | n/a | yes |
+| <a name="input_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#input\_terraform\_credentials\_group\_id) | ID of the credentials group that is used by Terraform to manage the bucket. A credential of this credential group must be used in the AWS provider config. If not provided, a new credentials group will be created. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -144,6 +144,6 @@ module "object_storage_bucket" {
 |------|-------------|
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
 | <a name="output_credentials"></a> [credentials](#output\_credentials) | Credentials to access the S3 bucket. Only available if `manage_credentials` is false |
-| <a name="output_terraform_credentials"></a> [terraform\_credentials](#output\_terraform\_credentials) | Credentials to manage S3 bucket via Terraform. This will be empty if `terraform_credentails_group_id` is provided. |
+| <a name="output_terraform_credentials"></a> [terraform\_credentials](#output\_terraform\_credentials) | Credentials to manage buckets via Terraform. Use these credentials when configuring the AWS provider. This will be empty if `terraform_credentials_group_id` is provided. |
 | <a name="output_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#output\_terraform\_credentials\_group\_id) | The ID of the credentials group used by Terraform to manage the S3 bucket. |
 <!-- END_TF_DOCS -->

--- a/stackit-object-storage/main.tf
+++ b/stackit-object-storage/main.tf
@@ -21,22 +21,23 @@ resource "stackit_objectstorage_bucket" "bucket" {
   name       = var.bucket_name
 }
 
-# Default terraform superuser credentials
-resource "stackit_objectstorage_credentials_group" "terraform_credentials_group" {
-  # depends_on needed to avoid 409, because of simultaneously requests
-  # REF: https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket
-  depends_on = [stackit_objectstorage_bucket.bucket]
-  count      = var.terraform_credentials_group_id == null ? 1 : 0
-
-  project_id = var.project_id
-  name       = "${var.bucket_name}-cg"
-}
-
 data "stackit_objectstorage_credentials_group" "existing_terraform_credentials_group" {
   count                = var.terraform_credentials_group_id != null ? 1 : 0
   project_id           = var.project_id
   credentials_group_id = var.terraform_credentials_group_id
 }
+
+# Default terraform superuser credentials
+resource "stackit_objectstorage_credentials_group" "terraform_credentials_group" {
+  count      = var.terraform_credentials_group_id == null ? 1 : 0
+  # depends_on needed to avoid 409, because of simultaneously requests
+  # REF: https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket
+  depends_on = [stackit_objectstorage_bucket.bucket]
+
+  project_id = var.project_id
+  name       = "${var.bucket_name}-cg"
+}
+
 
 resource "stackit_objectstorage_credential" "terraform_credentials" {
   count                = var.terraform_credentials_group_id == null ? 1 : 0

--- a/stackit-object-storage/main.tf
+++ b/stackit-object-storage/main.tf
@@ -5,6 +5,13 @@ locals {
     # THIS FILE IS MANAGED BY TERRAFORM
     ###
   EOT
+  access_codes = {
+    "read-only"  = "ro"
+    "read-write" = "rw"
+    "superuser"  = "su"
+  }
+
+  roles_used = toset([for name, role in var.credentials : role])
 }
 
 resource "stackit_objectstorage_bucket" "bucket" {
@@ -12,76 +19,112 @@ resource "stackit_objectstorage_bucket" "bucket" {
   name       = var.bucket_name
 }
 
-resource "stackit_objectstorage_credentials_group" "credentials_group" {
+# Default terraform superuser credentials
+resource "stackit_objectstorage_credentials_group" "terraform_credentials_group" {
   # depends_on needed to avoid 409, because of simultaneously requests
   # REF: https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket
   depends_on = [stackit_objectstorage_bucket.bucket]
+
   project_id = var.project_id
   name       = "${var.bucket_name}-cg"
 }
 
-resource "stackit_objectstorage_credential" "credential" {
-  for_each             = toset(var.credentials_names)
+resource "stackit_objectstorage_credential" "terraform_credentials" {
   project_id           = var.project_id
-  credentials_group_id = stackit_objectstorage_credentials_group.credentials_group.credentials_group_id
+  credentials_group_id = stackit_objectstorage_credentials_group.terraform_credentials_group.credentials_group_id
 }
 
-resource "vault_kv_secret_v2" "bucket_credentials" {
-  for_each = var.manage_credentials ? toset(var.credentials_names) : []
-  mount    = var.secret_manager_instance_id
-  name     = "object-storage/${stackit_objectstorage_bucket.bucket.name}/${each.key}"
+# Credentials requested by user with specific roles
+resource "stackit_objectstorage_credentials_group" "credentials_group" {
+  # depends_on needed to avoid 409, because of simultaneously requests
+  # REF: https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket
+  depends_on = [stackit_objectstorage_bucket.bucket]
 
-  data_json = jsonencode({
-    access_key        = stackit_objectstorage_credential.credential[each.key].access_key
-    secret_access_key = stackit_objectstorage_credential.credential[each.key].secret_access_key
-  })
+  for_each   = local.roles_used
+  project_id = var.project_id
+  name       = "${var.bucket_name}-${local.access_codes[each.key]}"
 }
 
-resource "local_file" "external_secret_manifest" {
-  count = var.manage_credentials ? 1 : 0
+resource "stackit_objectstorage_credential" "credential" {
+  for_each             = var.credentials
+  project_id           = var.project_id
+  credentials_group_id = stackit_objectstorage_credentials_group.credentials_group[each.value].credentials_group_id
+}
 
-  lifecycle {
-    precondition {
-      # Only create the file if manage_credentials is set (otherwise the resource would not be created at all)
-      # and error out if the filename was not provided.
-      condition     = var.external_secret_manifest != null && var.kubernetes_namespace != null
-      error_message = "You enabled 'manage_credentials' but did not provide 'external_secret_manifest' and 'kubernetes_namespace'."
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = stackit_objectstorage_bucket.bucket.name
+  policy = data.aws_iam_policy_document.combined_policy.json
+}
+
+data "aws_iam_policy_document" "combined_policy" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.disable_access_for_other_credentials_groups.json,
+    contains(local.roles_used, "read-only") ? data.aws_iam_policy_document.read_only[0].json : "",
+    contains(local.roles_used, "read-write") ? data.aws_iam_policy_document.read_write[0].json : "",
+  ]
+}
+
+data "aws_iam_policy_document" "disable_access_for_other_credentials_groups" {
+  statement {
+    effect = "Deny"
+    not_principals {
+      identifiers = concat([stackit_objectstorage_credentials_group.terraform_credentials_group.urn], [for cg in stackit_objectstorage_credentials_group.credentials_group : cg.urn])
+      type        = "AWS"
     }
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "arn:aws:s3:::${stackit_objectstorage_bucket.bucket.name}",
+      "arn:aws:s3:::${stackit_objectstorage_bucket.bucket.name}/*"
+    ]
   }
+}
 
-  filename = var.external_secret_manifest
+data "aws_iam_policy_document" "read_only" {
+  count = contains(local.roles_used, "read-only") ? 1 : 0
+  statement {
+    effect = "Deny"
+    principals {
+      identifiers = [stackit_objectstorage_credentials_group.credentials_group["read-only"].urn]
+      type        = "AWS"
+    }
+    actions = [
+      "s3:Create*",
+      "s3:Put*",
+      "s3:Delete*",
+      "s3:Restore*",
+      "s3:Abort*",
+    ]
+    resources = [
+      "arn:aws:s3:::${stackit_objectstorage_bucket.bucket.name}",
+      "arn:aws:s3:::${stackit_objectstorage_bucket.bucket.name}/*"
+    ]
+  }
+}
 
-  content = format("%s%s", local.yaml_autocreate_warning, join("\n---\n", [
-    for name in var.credentials_names : yamlencode({
-      apiVersion = "external-secrets.io/v1"
-      kind       = "ExternalSecret"
-      metadata = {
-        name      = "${var.bucket_name}-bucket-credentials-${name}"
-        namespace = var.kubernetes_namespace
-      }
-      spec = {
-        refreshInterval = "15m"
-        secretStoreRef = {
-          name = "secret-store"
-          kind = "SecretStore"
-        }
-        data = [
-          {
-            secretKey = "access_key"
-            remoteRef = {
-              key      = "object-storage/${stackit_objectstorage_bucket.bucket.name}/${name}"
-              property = "access_key"
-            }
-          },
-          {
-            secretKey = "secret_access_key"
-            remoteRef = {
-              key      = "object-storage/${stackit_objectstorage_bucket.bucket.name}/${name}"
-              property = "secret_access_key"
-            }
-          }
-        ]
-      }
-    })
-  ]))
+
+data "aws_iam_policy_document" "read_write" {
+  count = contains(local.roles_used, "read-write") ? 1 : 0
+  statement {
+    effect = "Deny"
+    principals {
+      identifiers = [stackit_objectstorage_credentials_group.credentials_group["read-write"].urn]
+      type        = "AWS"
+    }
+    actions = [
+      "s3:CreateBucket",
+      "s3:PutBucketPolicy",
+      "s3:PutBucketTagging",
+      "s3:DeleteBucketPolicy",
+      "s3:DeleteBucket",
+      "s3:PutEncryptionConfiguration",
+      "s3:PutReplicationConfiguration",
+      "s3:PutLifecycleConfiguration"
+    ]
+    resources = [
+      "arn:aws:s3:::${stackit_objectstorage_bucket.bucket.name}",
+      "arn:aws:s3:::${stackit_objectstorage_bucket.bucket.name}/*"
+    ]
+  }
 }

--- a/stackit-object-storage/main.tf
+++ b/stackit-object-storage/main.tf
@@ -29,7 +29,7 @@ data "stackit_objectstorage_credentials_group" "existing_terraform_credentials_g
 
 # Default terraform superuser credentials
 resource "stackit_objectstorage_credentials_group" "terraform_credentials_group" {
-  count      = var.terraform_credentials_group_id == null ? 1 : 0
+  count = var.terraform_credentials_group_id == null ? 1 : 0
   # depends_on needed to avoid 409, because of simultaneously requests
   # REF: https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/objectstorage_bucket
   depends_on = [stackit_objectstorage_bucket.bucket]

--- a/stackit-object-storage/main.tf
+++ b/stackit-object-storage/main.tf
@@ -69,7 +69,6 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
 data "aws_iam_policy_document" "combined_policy" {
   source_policy_documents = [
     data.aws_iam_policy_document.disable_access_for_other_credentials_groups.json,
-    data.aws_iam_policy_document.terraform_object_access.json,
     contains(local.roles_used, "read-only") ? data.aws_iam_policy_document.read_only[0].json : "",
     contains(local.roles_used, "read-write") ? data.aws_iam_policy_document.read_write[0].json : "",
   ]
@@ -132,29 +131,6 @@ data "aws_iam_policy_document" "read_write" {
       "s3:PutEncryptionConfiguration",
       "s3:PutReplicationConfiguration",
       "s3:PutLifecycleConfiguration"
-    ]
-    resources = [
-      "arn:aws:s3:::${stackit_objectstorage_bucket.bucket.name}",
-      "arn:aws:s3:::${stackit_objectstorage_bucket.bucket.name}/*"
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "terraform_object_access" {
-  statement {
-    effect = "Deny"
-    principals {
-      identifiers = [local.terraform_credentials_group_urn]
-      type        = "AWS"
-    }
-    actions = [
-      "s3:AbortMultipartUpload",
-      "s3:GetObject",
-      "s3:GetObjectVersion",
-      "s3:PutObject",
-      "s3:DeleteObject",
-      "s3:DeleteObjectVersion",
-      "s3:RestoreObject"
     ]
     resources = [
       "arn:aws:s3:::${stackit_objectstorage_bucket.bucket.name}",

--- a/stackit-object-storage/managed_credentials.tf
+++ b/stackit-object-storage/managed_credentials.tf
@@ -1,0 +1,61 @@
+
+resource "vault_kv_secret_v2" "bucket_credentials" {
+  for_each = var.manage_credentials ? var.credentials : {}
+  mount    = var.secret_manager_instance_id
+  name     = "object-storage/${stackit_objectstorage_bucket.bucket.name}/${each.key}"
+
+  data_json = jsonencode({
+    access_key        = stackit_objectstorage_credential.credential[each.key].access_key
+    secret_access_key = stackit_objectstorage_credential.credential[each.key].secret_access_key
+  })
+}
+
+resource "local_file" "external_secret_manifest" {
+  count = var.manage_credentials ? 1 : 0
+
+  lifecycle {
+    precondition {
+      # Only create the file if manage_credentials is set (otherwise the resource would not be created at all)
+      # and error out if the filename was not provided.
+      condition     = var.external_secret_manifest != null && var.kubernetes_namespace != null
+      error_message = "You enabled 'manage_credentials' but did not provide 'external_secret_manifest' and 'kubernetes_namespace'."
+    }
+  }
+
+  filename = var.external_secret_manifest
+
+  content = format("%s%s", local.yaml_autocreate_warning, join("\n---\n", [
+    for name, role in var.credentials : yamlencode({
+      apiVersion = "external-secrets.io/v1"
+      kind       = "ExternalSecret"
+      metadata = {
+        name      = "${var.bucket_name}-bucket-credentials-${name}"
+        namespace = var.kubernetes_namespace
+      }
+      spec = {
+        refreshInterval = "15m"
+        secretStoreRef = {
+          name = "secret-store"
+          kind = "SecretStore"
+        }
+        data = [
+          {
+            secretKey = "access_key"
+            remoteRef = {
+              key      = "object-storage/${stackit_objectstorage_bucket.bucket.name}/${name}"
+              property = "access_key"
+            }
+          },
+          {
+            secretKey = "secret_access_key"
+            remoteRef = {
+              key      = "object-storage/${stackit_objectstorage_bucket.bucket.name}/${name}"
+              property = "secret_access_key"
+            }
+          }
+        ]
+      }
+    })
+  ]))
+}
+

--- a/stackit-object-storage/outputs.tf
+++ b/stackit-object-storage/outputs.tf
@@ -12,10 +12,10 @@ output "credentials" {
 output "terraform_credentials" {
   sensitive   = true
   description = "Credentials to manage S3 bucket via Terraform"
-    value = {
-        access_key        = stackit_objectstorage_credential.terraform_credentials.access_key
-        secret_access_key = stackit_objectstorage_credential.terraform_credentials.secret_access_key
-    }
+  value = {
+    access_key        = stackit_objectstorage_credential.terraform_credentials.access_key
+    secret_access_key = stackit_objectstorage_credential.terraform_credentials.secret_access_key
+  }
 }
 
 output "bucket_name" {

--- a/stackit-object-storage/outputs.tf
+++ b/stackit-object-storage/outputs.tf
@@ -11,11 +11,16 @@ output "credentials" {
 
 output "terraform_credentials" {
   sensitive   = true
-  description = "Credentials to manage S3 bucket via Terraform"
-  value = {
-    access_key        = stackit_objectstorage_credential.terraform_credentials.access_key
-    secret_access_key = stackit_objectstorage_credential.terraform_credentials.secret_access_key
+  description = "Credentials to manage S3 bucket via Terraform. This will be empty if `terraform_credentails_group_id` is provided."
+  value = var.terraform_credentials_group_id != null ? {} : {
+    access_key        = stackit_objectstorage_credential.terraform_credentials[0].access_key
+    secret_access_key = stackit_objectstorage_credential.terraform_credentials[0].secret_access_key
   }
+}
+
+output "terraform_credentials_group_id" {
+  description = "The ID of the credentials group used by Terraform to manage the S3 bucket."
+  value       = var.terraform_credentials_group_id != null ? var.terraform_credentials_group_id : stackit_objectstorage_credentials_group.terraform_credentials_group[0].credentials_group_id
 }
 
 output "bucket_name" {

--- a/stackit-object-storage/outputs.tf
+++ b/stackit-object-storage/outputs.tf
@@ -2,11 +2,20 @@ output "credentials" {
   sensitive   = true
   description = "Credentials to access the S3 bucket. Only available if `manage_credentials` is false"
   value = var.manage_credentials ? {} : {
-    for name in var.credentials_names : name => {
+    for name, role in var.credentials : name => {
       access_key        = stackit_objectstorage_credential.credential[name].access_key
       secret_access_key = stackit_objectstorage_credential.credential[name].secret_access_key
     }
   }
+}
+
+output "terraform_credentials" {
+  sensitive   = true
+  description = "Credentials to manage S3 bucket via Terraform"
+    value = {
+        access_key        = stackit_objectstorage_credential.terraform_credentials.access_key
+        secret_access_key = stackit_objectstorage_credential.terraform_credentials.secret_access_key
+    }
 }
 
 output "bucket_name" {

--- a/stackit-object-storage/outputs.tf
+++ b/stackit-object-storage/outputs.tf
@@ -11,7 +11,7 @@ output "credentials" {
 
 output "terraform_credentials" {
   sensitive   = true
-  description = "Credentials to manage S3 bucket via Terraform. This will be empty if `terraform_credentails_group_id` is provided."
+  description = "Credentials to manage buckets via Terraform. Use these credentials when configuring the AWS provider. This will be empty if `terraform_credentials_group_id` is provided."
   value = var.terraform_credentials_group_id != null ? {} : {
     access_key        = stackit_objectstorage_credential.terraform_credentials[0].access_key
     secret_access_key = stackit_objectstorage_credential.terraform_credentials[0].secret_access_key

--- a/stackit-object-storage/terraform.tf
+++ b/stackit-object-storage/terraform.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/vault"
       version = ">=5.3.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.28.0"
+    }
   }
 }
 

--- a/stackit-object-storage/tests/object_storage.tftest.hcl
+++ b/stackit-object-storage/tests/object_storage.tftest.hcl
@@ -31,7 +31,7 @@ mock_provider "vault" {
     }
   }
 }
-mock_provider "aws"{
+mock_provider "aws" {
   mock_data "aws_iam_policy_document" {
     defaults = {
       json = "{\"Statement\":[],\"Version\":\"2012-10-17\"}"

--- a/stackit-object-storage/tests/object_storage.tftest.hcl
+++ b/stackit-object-storage/tests/object_storage.tftest.hcl
@@ -40,8 +40,9 @@ mock_provider "aws" {
 }
 
 variables {
-  project_id               = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
-  external_secret_manifest = "secret.yaml"
+  project_id                     = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
+  external_secret_manifest       = "secret.yaml"
+  terraform_credentials_group_id = null
 }
 
 # Test 1: Default configuration with only terraform credential
@@ -58,7 +59,7 @@ run "default_configuration" {
   }
 
   assert {
-    condition     = stackit_objectstorage_credentials_group.terraform_credentials_group.name == "test-bucket-default-cg"
+    condition     = stackit_objectstorage_credentials_group.terraform_credentials_group[0].name == "test-bucket-default-cg"
     error_message = "Credentials group name does not match expected format"
   }
 
@@ -130,7 +131,7 @@ run "max_bucket_name_length" {
   }
 
   assert {
-    condition     = length(stackit_objectstorage_credentials_group.terraform_credentials_group.name) <= 32
+    condition     = length(stackit_objectstorage_credentials_group.terraform_credentials_group[0].name) <= 32
     error_message = "Credentials group name should not exceed 32 characters"
   }
 }

--- a/stackit-object-storage/tests/policies.tftest.hcl
+++ b/stackit-object-storage/tests/policies.tftest.hcl
@@ -58,21 +58,21 @@ run "policy_generation" {
     }
   }
   override_resource {
-    target = stackit_objectstorage_credentials_group.credentials_group["superuser"]
+    target = stackit_objectstorage_credentials_group.user_credentials_group["superuser"]
     values = {
       credentials_group_id = "636573b0-f12d-461a-ac55-5078a1bf18f5"
       urn                  = "urn:stackit:objectstorage:credentialsgroup:su"
     }
   }
   override_resource {
-    target = stackit_objectstorage_credentials_group.credentials_group["read-write"]
+    target = stackit_objectstorage_credentials_group.user_credentials_group["read-write"]
     values = {
       credentials_group_id = "3b5f9bef-9040-4351-817e-c8a0f92eece8"
       urn                  = "urn:stackit:objectstorage:credentialsgroup:rw"
     }
   }
   override_resource {
-    target = stackit_objectstorage_credentials_group.credentials_group["read-only"]
+    target = stackit_objectstorage_credentials_group.user_credentials_group["read-only"]
     values = {
       credentials_group_id = "2831a53d-dc92-471e-b280-75f2843383f1"
       urn                  = "urn:stackit:objectstorage:credentialsgroup:ro"
@@ -81,7 +81,7 @@ run "policy_generation" {
 
 
   assert {
-    condition     = length(keys(stackit_objectstorage_credentials_group.credentials_group)) == 3
+    condition     = length(keys(stackit_objectstorage_credentials_group.user_credentials_group)) == 3
     error_message = "Should create exactly three credential groups"
   }
   assert {

--- a/stackit-object-storage/tests/policies.tftest.hcl
+++ b/stackit-object-storage/tests/policies.tftest.hcl
@@ -79,7 +79,6 @@ run "policy_generation" {
     }
   }
 
-
   assert {
     condition     = length(keys(stackit_objectstorage_credentials_group.user_credentials_group)) == 3
     error_message = "Should create exactly three credential groups"

--- a/stackit-object-storage/tests/policies.tftest.hcl
+++ b/stackit-object-storage/tests/policies.tftest.hcl
@@ -13,6 +13,14 @@ mock_provider "stackit" {
       project_id        = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
     }
   }
+
+  mock_data "stackit_objectstorage_credentials_group" {
+    defaults = {
+      credentials_group_id = "12168432-2b8f-44de-8514-11bd9f9ad8b6"
+      project_id           = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
+      urn                  = "urn:stackit:objectstorage:credentialsgroup:existing_tf_group"
+    }
+  }
 }
 
 # Mocking the AWS provider to avoid real API calls during testing
@@ -32,6 +40,35 @@ override_resource {
   target = aws_s3_bucket_policy.bucket_policy
 }
 
+override_resource {
+  target = stackit_objectstorage_credentials_group.terraform_credentials_group
+  values = {
+    credentials_group_id = "5f2001ad-75b0-46f2-900d-1ab8d39b6a7d"
+    urn                  = "urn:stackit:objectstorage:credentialsgroup:terraform"
+  }
+}
+override_resource {
+  target = stackit_objectstorage_credentials_group.user_credentials_group["superuser"]
+  values = {
+    credentials_group_id = "636573b0-f12d-461a-ac55-5078a1bf18f5"
+    urn                  = "urn:stackit:objectstorage:credentialsgroup:su"
+  }
+}
+override_resource {
+  target = stackit_objectstorage_credentials_group.user_credentials_group["read-write"]
+  values = {
+    credentials_group_id = "3b5f9bef-9040-4351-817e-c8a0f92eece8"
+    urn                  = "urn:stackit:objectstorage:credentialsgroup:rw"
+  }
+}
+override_resource {
+  target = stackit_objectstorage_credentials_group.user_credentials_group["read-only"]
+  values = {
+    credentials_group_id = "2831a53d-dc92-471e-b280-75f2843383f1"
+    urn                  = "urn:stackit:objectstorage:credentialsgroup:ro"
+  }
+}
+
 
 variables {
   project_id               = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
@@ -41,41 +78,13 @@ variables {
 run "policy_generation" {
   command = apply
   variables {
-    bucket_name = "test-bucket-default"
+    bucket_name                    = "test-bucket-default"
+    terraform_credentials_group_id = null
     credentials = {
       "credential-1" = "superuser"
       "credential-2" = "read-write"
       "credential-3" = "read-only"
       "credential-4" = "read-only"
-    }
-  }
-
-  override_resource {
-    target = stackit_objectstorage_credentials_group.terraform_credentials_group
-    values = {
-      credentials_group_id = "5f2001ad-75b0-46f2-900d-1ab8d39b6a7d"
-      urn                  = "urn:stackit:objectstorage:credentialsgroup:terraform"
-    }
-  }
-  override_resource {
-    target = stackit_objectstorage_credentials_group.user_credentials_group["superuser"]
-    values = {
-      credentials_group_id = "636573b0-f12d-461a-ac55-5078a1bf18f5"
-      urn                  = "urn:stackit:objectstorage:credentialsgroup:su"
-    }
-  }
-  override_resource {
-    target = stackit_objectstorage_credentials_group.user_credentials_group["read-write"]
-    values = {
-      credentials_group_id = "3b5f9bef-9040-4351-817e-c8a0f92eece8"
-      urn                  = "urn:stackit:objectstorage:credentialsgroup:rw"
-    }
-  }
-  override_resource {
-    target = stackit_objectstorage_credentials_group.user_credentials_group["read-only"]
-    values = {
-      credentials_group_id = "2831a53d-dc92-471e-b280-75f2843383f1"
-      urn                  = "urn:stackit:objectstorage:credentialsgroup:ro"
     }
   }
 
@@ -110,5 +119,33 @@ run "policy_generation" {
     )
     error_message = "Read-write policy is incorrect"
   }
+}
 
+
+run "exsting_terraform_credential_group" {
+  command = apply
+
+  variables {
+    bucket_name                    = "test-bucket-existing-tf-cred"
+    terraform_credentials_group_id = "12168432-2b8f-44de-8514-11bd9f9ad8b6"
+    credentials                    = { ro = "read-only" }
+  }
+
+  assert {
+    condition     = stackit_objectstorage_credentials_group.terraform_credentials_group == []
+    error_message = "Should not create a new terraform credentials group when an existing ID is provided"
+  }
+
+  assert {
+    condition     = length(stackit_objectstorage_credential.terraform_credentials) == 0
+    error_message = "Should not create terraform credentials when an existing credentials group ID is provided"
+  }
+
+  assert {
+    condition = (
+      jsondecode(data.aws_iam_policy_document.combined_policy.json).Statement[0].Action == "s3:*" &&
+      jsondecode(data.aws_iam_policy_document.combined_policy.json).Statement[0].NotPrincipal.AWS == ["urn:stackit:objectstorage:credentialsgroup:ro", "urn:stackit:objectstorage:credentialsgroup:existing_tf_group"]
+    )
+    error_message = "Policy to restrict access for other credentials groups is incorrect"
+  }
 }

--- a/stackit-object-storage/tests/policies.tftest.hcl
+++ b/stackit-object-storage/tests/policies.tftest.hcl
@@ -1,0 +1,115 @@
+mock_provider "stackit" {
+  mock_resource "stackit_objectstorage_bucket" {
+    defaults = {
+      id         = "bucket-123"
+      project_id = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
+    }
+  }
+
+  mock_resource "stackit_objectstorage_credential" {
+    defaults = {
+      access_key        = "mock-access-key"
+      secret_access_key = "mock-secret-key"
+      project_id        = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
+    }
+  }
+}
+
+# Mocking the AWS provider to avoid real API calls during testing
+# Can't use the mock_provider for aws because it would override the aws_iam_policy_document data source
+provider "aws" {
+  region     = "us-east-1"
+  access_key = "mock_access_key"
+  secret_key = "mock_secret_key"
+
+  # specific flags to skip auth and API calls
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+}
+
+override_resource {
+  target = aws_s3_bucket_policy.bucket_policy
+}
+
+
+variables {
+  project_id               = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
+  external_secret_manifest = "secret.yaml"
+}
+
+run "policy_generation" {
+  command = apply
+  variables {
+    bucket_name = "test-bucket-default"
+    credentials = {
+      "credential-1" = "superuser"
+      "credential-2" = "read-write"
+      "credential-3" = "read-only"
+      "credential-4" = "read-only"
+    }
+  }
+
+  override_resource {
+    target = stackit_objectstorage_credentials_group.terraform_credentials_group
+    values = {
+      credentials_group_id = "5f2001ad-75b0-46f2-900d-1ab8d39b6a7d"
+      urn                  = "urn:stackit:objectstorage:credentialsgroup:terraform"
+    }
+  }
+  override_resource {
+    target = stackit_objectstorage_credentials_group.credentials_group["superuser"]
+    values = {
+      credentials_group_id = "636573b0-f12d-461a-ac55-5078a1bf18f5"
+      urn                  = "urn:stackit:objectstorage:credentialsgroup:su"
+    }
+  }
+  override_resource {
+    target = stackit_objectstorage_credentials_group.credentials_group["read-write"]
+    values = {
+      credentials_group_id = "3b5f9bef-9040-4351-817e-c8a0f92eece8"
+      urn                  = "urn:stackit:objectstorage:credentialsgroup:rw"
+    }
+  }
+  override_resource {
+    target = stackit_objectstorage_credentials_group.credentials_group["read-only"]
+    values = {
+      credentials_group_id = "2831a53d-dc92-471e-b280-75f2843383f1"
+      urn                  = "urn:stackit:objectstorage:credentialsgroup:ro"
+    }
+  }
+
+
+  assert {
+    condition     = length(keys(stackit_objectstorage_credentials_group.credentials_group)) == 3
+    error_message = "Should create exactly three credential groups"
+  }
+  assert {
+    condition     = length(keys(stackit_objectstorage_credential.credential)) == 4
+    error_message = "Should create exactly four credentials"
+  }
+  assert {
+    condition = (
+      jsondecode(data.aws_iam_policy_document.combined_policy.json).Statement[0].Action == "s3:*" &&
+      jsondecode(data.aws_iam_policy_document.combined_policy.json).Statement[0].NotPrincipal.AWS == ["urn:stackit:objectstorage:credentialsgroup:terraform", "urn:stackit:objectstorage:credentialsgroup:su", "urn:stackit:objectstorage:credentialsgroup:rw", "urn:stackit:objectstorage:credentialsgroup:ro"]
+    )
+    error_message = "Policy to restrict access for other credentials groups is incorrect"
+  }
+
+  assert {
+    condition = (
+      jsondecode(data.aws_iam_policy_document.combined_policy.json).Statement[1].Action == ["s3:Restore*", "s3:Put*", "s3:Delete*", "s3:Create*", "s3:Abort*"] &&
+      jsondecode(data.aws_iam_policy_document.combined_policy.json).Statement[1].Principal.AWS == "urn:stackit:objectstorage:credentialsgroup:ro"
+    )
+    error_message = "Read-only policy is incorrect"
+  }
+
+  assert {
+    condition = (
+      jsondecode(data.aws_iam_policy_document.combined_policy.json).Statement[2].Action == ["s3:PutReplicationConfiguration", "s3:PutLifecycleConfiguration", "s3:PutEncryptionConfiguration", "s3:PutBucketTagging", "s3:PutBucketPolicy", "s3:DeleteBucketPolicy", "s3:DeleteBucket", "s3:CreateBucket"] &&
+      jsondecode(data.aws_iam_policy_document.combined_policy.json).Statement[2].Principal.AWS == "urn:stackit:objectstorage:credentialsgroup:rw"
+    )
+    error_message = "Read-write policy is incorrect"
+  }
+
+}

--- a/stackit-object-storage/variables.tf
+++ b/stackit-object-storage/variables.tf
@@ -13,10 +13,20 @@ variable "bucket_name" {
   }
 }
 
-variable "credentials_names" {
-  description = "Names of credentials to create for the bucket. Defaults to ['default']."
-  type        = list(string)
-  default     = ["default"]
+variable "credentials" {
+  description = "Credentials to create for the bucket. Map of credential name to role. Valid roles are: superuser, read-only, read-write."
+  type        = map(string)
+  default = {
+    default = "superuser"
+  }
+
+  validation {
+    condition = alltrue([
+      for c in values(var.credentials) : contains(["superuser", "read-only", "read-write"], c)
+    ])
+    error_message = "Each credential role must be one of: superuser, read-only, read-write."
+
+  }
 }
 
 variable "manage_credentials" {

--- a/stackit-object-storage/variables.tf
+++ b/stackit-object-storage/variables.tf
@@ -14,7 +14,7 @@ variable "bucket_name" {
 }
 
 variable "credentials" {
-  description = "Credentials to create for the bucket. Map of credential name to role. Valid roles are: superuser, read-only, read-write."
+  description = "Credentials to create for the bucket. Map of credential name to role (e.g. { name = role }. Valid roles are: superuser, read-only, read-write."
   type        = map(string)
   default = {
     default = "superuser"
@@ -30,7 +30,7 @@ variable "credentials" {
 }
 
 variable "terraform_credentials_group_id" {
-  description = "ID of the credentials group that is used by Terraform to manage the bucket. If not provided, a new credentials group will be created."
+  description = "ID of the credentials group that is used by Terraform to manage the bucket. A credential of this credential group must be used in the AWS provider config. If not provided, a new credentials group will be created."
   type        = string
 }
 

--- a/stackit-object-storage/variables.tf
+++ b/stackit-object-storage/variables.tf
@@ -29,6 +29,11 @@ variable "credentials" {
   }
 }
 
+variable "terraform_credentials_group_id" {
+  description = "ID of the credentials group that is used by Terraform to manage the bucket. If not provided, a new credentials group will be created."
+  type        = string
+}
+
 variable "manage_credentials" {
   description = "Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]`"
   type        = bool

--- a/stackit-state-bucket/.terraform.lock.hcl
+++ b/stackit-state-bucket/.terraform.lock.hcl
@@ -1,6 +1,49 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.28.0"
+  constraints = ">= 6.28.0"
+  hashes = [
+    "h1:RwoFuX1yGMVaKJaUmXDKklEaQ/yUCEdt5k2kz+/g08c=",
+    "zh:0ba0d5eb6e0c6a933eb2befe3cdbf22b58fbc0337bf138f95bf0e8bb6e6df93e",
+    "zh:23eacdd4e6db32cf0ff2ce189461bdbb62e46513978d33c5de4decc4670870ec",
+    "zh:307b06a15fc00a8e6fd243abde2cbe5112e9d40371542665b91bec1018dd6e3c",
+    "zh:37a02d5b45a9d050b9642c9e2e268297254192280df72f6e46641daca52e40ec",
+    "zh:3da866639f07d92e734557d673092719c33ede80f4276c835bf7f231a669aa33",
+    "zh:480060b0ba310d0f6b6a14d60b276698cb103c48fd2f7e2802ae47c963995ec6",
+    "zh:57796453455c20db80d9168edbf125bf6180e1aae869de1546a2be58e4e405ec",
+    "zh:69139cba772d4df8de87598d8d8a2b1b4b254866db046c061dccc79edb14e6b9",
+    "zh:7312763259b859ff911c5452ca8bdf7d0be6231c5ea0de2df8f09d51770900ac",
+    "zh:8d2d6f4015d3c155d7eb53e36f019a729aefb46ebfe13f3a637327d3a1402ecc",
+    "zh:94ce589275c77308e6253f607de96919b840c2dd36c44aa798f693c9dd81af42",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:adaceec6a1bf4f5df1e12bd72cf52b72087c72efed078aef636f8988325b1a8b",
+    "zh:d37be1ce187d94fd9df7b13a717c219964cd835c946243f096c6b230cdfd7e92",
+    "zh:fe6205b5ca2ff36e68395cb8d3ae10a3728f405cdbcd46b206a515e1ebcf17a1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.6.1"
+  constraints = ">= 2.6.1"
+  hashes = [
+    "h1:DbiR/D2CPigzCGweYIyJH0N0x04oyI5xiZ9wSW/s3kQ=",
+    "zh:10050d08f416de42a857e4b6f76809aae63ea4ec6f5c852a126a915dede814b4",
+    "zh:2df2a3ebe9830d4759c59b51702e209fe053f47453cb4688f43c063bac8746b7",
+    "zh:2e759568bcc38c86ca0e43701d34cf29945736fdc8e429c5b287ddc2703c7b18",
+    "zh:6a62a34e48500ab4aea778e355e162ebde03260b7a9eb9edc7e534c84fbca4c6",
+    "zh:74373728ba32a1d5450a3a88ac45624579e32755b086cd4e51e88d9aca240ef6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8dddae588971a996f622e7589cd8b9da7834c744ac12bfb59c97fa77ded95255",
+    "zh:946f82f66353bb97aefa8d95c4ca86db227f9b7c50b82415289ac47e4e74d08d",
+    "zh:e9a5c09e6f35e510acf15b666fd0b34a30164cecdcd81ce7cda0f4b2dade8d91",
+    "zh:eafe5b873ef42b32feb2f969c38ff8652507e695620cbaf03b9db714bee52249",
+    "zh:ec146289fa27650c9d433bb5c7847379180c0b7a323b1b94e6e7ad5d2a7dbe71",
+    "zh:fc882c35ce05631d76c0973b35adde26980778fc81d9da81a2fade2b9d73423b",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.4"
   hashes = [

--- a/stackit-state-bucket/README.md
+++ b/stackit-state-bucket/README.md
@@ -35,6 +35,7 @@ You can disable all the magic with inputs.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >1.10.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=6.28.0 |
 | <a name="requirement_stackit"></a> [stackit](#requirement\_stackit) | >=0.65.0 |
 
 ## Providers

--- a/stackit-state-bucket/README.md
+++ b/stackit-state-bucket/README.md
@@ -95,4 +95,5 @@ You can disable all the magic with inputs.
 | <a name="output_envrc_file"></a> [envrc\_file](#output\_envrc\_file) | Content of the .envrc file to set environment variables for accessing the backend bucket. |
 | <a name="output_onepassword_command"></a> [onepassword\_command](#output\_onepassword\_command) | The 1Password CLI command that needs to be executed to add the bucket credentials to 1Password. |
 | <a name="output_secret_access_key"></a> [secret\_access\_key](#output\_secret\_access\_key) | Secret access key to access the backend bucket. Export this value as AWS\_SECRET\_ACCESS\_KEY to access the bucket. |
+| <a name="output_terraform_credentials_group_id"></a> [terraform\_credentials\_group\_id](#output\_terraform\_credentials\_group\_id) | The ID of the credentials group used by Terraform to manage the S3 bucket. |
 <!-- END_TF_DOCS -->

--- a/stackit-state-bucket/README.md
+++ b/stackit-state-bucket/README.md
@@ -21,11 +21,28 @@ bootstrap your terraform configuration by setting up the remote state for you.
      onepassword_vault = "[your team vault name]"
    }
    ```
-2. Run `terraform init` and `terraform apply`
-3. A `backend.tf` should have been generated in your terraform folder
-4. A `.envrc` file should have been generated in your terraform folder
-5. A 1Password item should have been generated in your teams vault
-6. Run `terraform init` to migrate your local state to the remote state bucket
+2. Add the `aws` provider config to you `providers.tf` file
+   ```hcl
+    provider "aws" {
+      region                      = "eu01"
+      skip_credentials_validation = true
+      skip_region_validation      = true
+      skip_requesting_account_id  = true
+    
+      access_key = module.backend_bucket.access_key
+      secret_key = module.backend_bucket.secret_access_key
+    
+      endpoints {
+        s3 = "https://object.storage.eu01.onstackit.cloud"
+      }
+    }
+   ```
+   This is needed to configure access policies on the bucket.
+3. Run `terraform init` and `terraform apply`
+4. A `backend.tf` should have been generated in your terraform folder
+5. A `.envrc` file should have been generated in your terraform folder
+6. A 1Password item should have been generated in your teams vault
+7. Run `terraform init` to migrate your local state to the remote state bucket
 
 You can disable all the magic with inputs.
 

--- a/stackit-state-bucket/main.tf
+++ b/stackit-state-bucket/main.tf
@@ -2,6 +2,7 @@ module "object_storage" {
   source      = "../stackit-object-storage"
   project_id  = var.project_id
   bucket_name = var.state_bucket_name
+  credentials = {} # No additional credentials needed
 }
 
 locals {
@@ -34,8 +35,8 @@ export AWS_SECRET_ACCESS_KEY="op://${var.onepassword_vault}/${module.object_stor
     "op item create --vault %q --category 'Secure Note' --title %q 'ACCESS_KEY_ID[text]=%s' 'SECRET_ACCESS_KEY[text]=%s'",
     var.onepassword_vault,
     "${module.object_storage.bucket_name} credentials",
-    module.object_storage.credentials["default"].access_key,
-    module.object_storage.credentials["default"].secret_access_key
+    module.object_storage.terraform_credentials.access_key,
+    module.object_storage.terraform_credentials.secret_access_key
   )
 }
 

--- a/stackit-state-bucket/main.tf
+++ b/stackit-state-bucket/main.tf
@@ -1,8 +1,9 @@
 module "object_storage" {
-  source      = "../stackit-object-storage"
-  project_id  = var.project_id
-  bucket_name = var.state_bucket_name
-  credentials = {} # No additional credentials needed
+  source                         = "../stackit-object-storage"
+  project_id                     = var.project_id
+  bucket_name                    = var.state_bucket_name
+  credentials                    = {}   # No additional credentials needed
+  terraform_credentials_group_id = null # Let the module create credentials for Terraform
 }
 
 locals {

--- a/stackit-state-bucket/outputs.tf
+++ b/stackit-state-bucket/outputs.tf
@@ -1,12 +1,12 @@
 output "access_key" {
   description = "Access key id to access the backend bucket. Export this value as AWS_ACCESS_KEY_ID to access the bucket."
-  value       = module.object_storage.credentials["default"].access_key
+  value       = module.object_storage.terraform_credentials.access_key
   sensitive   = true
 }
 
 output "secret_access_key" {
   description = "Secret access key to access the backend bucket. Export this value as AWS_SECRET_ACCESS_KEY to access the bucket."
-  value       = module.object_storage.credentials["default"].secret_access_key
+  value       = module.object_storage.terraform_credentials.secret_access_key
   sensitive   = true
 }
 

--- a/stackit-state-bucket/outputs.tf
+++ b/stackit-state-bucket/outputs.tf
@@ -10,6 +10,11 @@ output "secret_access_key" {
   sensitive   = true
 }
 
+output "terraform_credentials_group_id" {
+  description = "The ID of the credentials group used by Terraform to manage the S3 bucket."
+  value       = module.object_storage.terraform_credentials_group_id
+}
+
 output "backend_file" {
   description = "Content of the backend configuration file for Terraform."
   value       = local.backend_file

--- a/stackit-state-bucket/terraform.tf
+++ b/stackit-state-bucket/terraform.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "stackitcloud/stackit"
       version = ">=0.65.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=6.28.0"
+    }
   }
 }

--- a/stackit-state-bucket/tests/state_bucket.tftest.hcl
+++ b/stackit-state-bucket/tests/state_bucket.tftest.hcl
@@ -22,6 +22,14 @@ mock_provider "stackit" {
   }
 }
 
+mock_provider "aws"{
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Statement\":[],\"Version\":\"2012-10-17\"}"
+    }
+  }
+}
+
 variables {
   project_id = "aeac146a-97d6-4677-91eb-6ab5f8b0c202"
 }


### PR DESCRIPTION
# Migration Steps

## 1. Migration of `stackit-state-bucket` module:

### Provider:
Add this to `required_providers`:
```
    aws = {
      source  = "hashicorp/aws"
      version = ">=6.28.0"
    }
```

Add the aws provider config:
```hcl

provider "aws" {
  region                      = "eu01"
  skip_credentials_validation = true
  skip_region_validation      = true
  skip_requesting_account_id  = true

  access_key = module.backend_bucket.access_key
  secret_key = module.backend_bucket.secret_access_key

  endpoints {
    s3 = "https://object.storage.eu01.onstackit.cloud"
  }
}
```

### Move resources

```hcl
moved {
  from = module.backend_bucket.module.object_storage.stackit_objectstorage_credentials_group.credentials_group
  to   = module.backend_bucket.module.object_storage.stackit_objectstorage_credentials_group.terraform_credentials_group[0]
}

moved {
  from = module.backend_bucket.module.object_storage.stackit_objectstorage_credential.credential["default"]
  to   = module.backend_bucket.module.object_storage.stackit_objectstorage_credential.terraform_credentials[0]
}

moved {
  from =  module.backend_bucket.module.object_storage.stackit_objectstorage_bucket.state_bucket
  to   =  module.backend_bucket.module.object_storage.stackit_objectstorage_bucket.bucket
}
```

Result should be a plan with:
`Plan: 1 to add, 0 to change, 0 to destroy.`

## 2. Run `terraform apply` to apply the changes

## 3.  Migration for `stackit-object-storage` module (if used)
### Provider
Same as in `stackit-state-bucket` module

### Move resources
```hcl
moved {
  from = module.object_storage_bucket.stackit_objectstorage_credentials_group.credentials_group
  to   = module.object_storage_bucket.stackit_objectstorage_credentials_group.user_credentials_group["superuser"]
}

```

Expected Plan with 1 default credential: 
`Plan: 3 to add, 1 to change, 2 to destroy.`

⚠️ This change will break your existing credentials, but if you are using secrets manager, the new credentials will be updated in there as well

