### PR TITLE
feat(postgres-db)!: allow for custom secret paths

### DIFF
--- a/stackit-postgres-db/README.md
+++ b/stackit-postgres-db/README.md
@@ -8,9 +8,9 @@ databases, and users, while optionally integrating with STACKIT Secrets Manager 
 To minimize configuration for simple use cases, this module uses "Convention over Configuration" with fallback logic:
 
 | Resource       | Logic                                                                                                                                                 |
-|:---------------|:------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Databases**  | Creates databases listed in `database_names`. <br> *Fallback:* If the list is empty, creates a single database named after the instance (`var.name`). |
-| **Admin User** | Creates an admin user named `admin_spec.name`. <br> *Fallback:* If not set, creates a user named after the instance (`var.name`).                          |
+| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Databases**  | Creates databases listed in `database_names`. <br> _Fallback:_ If the list is empty, creates a single database named after the instance (`var.name`). |
+| **Admin User** | Creates an admin user named `admin_user.name`. <br> _Fallback:_ If not set, creates a user named after the instance (`var.name`).                     |
 
 ## Usage Example
 
@@ -26,8 +26,8 @@ To minimize configuration for simple use cases, this module uses "Convention ove
   acls = ["cluster", "egress", "range"] # Ask the platform team for the correct egress range
 
   database_names = ["list-of-names", "to-create-databases"] # optional, will fallback to `var.name` if not present
-  admin_spec = { name = "root" } # optional, will fallback to `var.name` if not present
-  user_spec_map = { lorem = { name = "lorem" }, ipsum = { name = "ipsum" } } # optional
+  admin_user = { name = "root" } # optional, will fallback to `var.name` if not present
+  additional_users = { lorem = { name = "lorem" }, ipsum = { name = "ipsum" } } # optional
 
   secret_manager_instance_id = "[your secrets manager instance id]"
   # available as output from stackit-secrets-manager module
@@ -109,7 +109,8 @@ When the variable is not set, the manifest will not be created.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acls"></a> [acls](#input\_acls) | List of ACL IDs to associate with the database instance. This should be the cluster Egress IP Range only! | `list(string)` | n/a | yes |
-| <a name="input_admin_spec"></a> [admin\_spec](#input\_admin\_spec) | Specified the name of the Postgres Database Owner and (optionally) a custom Secret Manager path. Example: { name = "admin", secret\_manager\_path = "custom/path/admin" }. If secret\_manager\_path is omitted, a default path is used. | <pre>object({<br/>    name                = string<br/>    secret_manager_path = optional(string)<br/>  })</pre> | <pre>{<br/>  "name": null<br/>}</pre> | no |
+| <a name="input_additional_users"></a> [additional\_users](#input\_additional\_users) | List of additional database users to create. Names must be unique. Example: [{ name = "user1", secret\_manager\_path = "custom/path/user1" }, { name = "user2" }]. If secret\_manager\_path is omitted for a user, a default path is used. | <pre>list(object({<br/>    name                = string<br/>    secret_manager_path = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_admin_user"></a> [admin\_user](#input\_admin\_user) | Specified the name of the Postgres Database Owner and (optionally) a custom Secret Manager path. Example: { name = "admin", secret\_manager\_path = "custom/path/admin" }. If secret\_manager\_path is omitted, a default path is used. If admin\_user is not specified, a user with the same name as the instance will be created. | <pre>object({<br/>    name                = string<br/>    secret_manager_path = optional(string)<br/>  })</pre> | <pre>{<br/>  "name": null<br/>}</pre> | no |
 | <a name="input_backup_schedule"></a> [backup\_schedule](#input\_backup\_schedule) | Backup schedule in cron format. Defaults to daily at 3am UTC. | `string` | `"0 3 * * *"` | no |
 | <a name="input_config_map_manifest"></a> [config\_map\_manifest](#input\_config\_map\_manifest) | Path where the config map manifest will be stored at | `string` | `null` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | Specifies the CPU specs of the instance. Available Options: 2, 4, 8 & 16 | `number` | n/a | yes |
@@ -125,7 +126,6 @@ When the variable is not set, the manifest will not be created.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the STACKIT project where the database will be created. | `string` | n/a | yes |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of read replicas for the instance. | `number` | `1` | no |
 | <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id) | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_user\_password is true. | `string` | `""` | no |
-| <a name="input_user_spec_map"></a> [user\_spec\_map](#input\_user\_spec\_map) | Map of additional database users to create. Elements must be unique. Example: { user1 = { name = "user1", secret\_manager\_path = "custom/path/user1" }, user2 = { name = "user2" } }. If secret\_manager\_path is omitted for a user, a default path is used. | <pre>map(object({<br/>    name                = string<br/>    secret_manager_path = optional(string)<br/>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/stackit-postgres-db/README.md
+++ b/stackit-postgres-db/README.md
@@ -10,7 +10,7 @@ To minimize configuration for simple use cases, this module uses "Convention ove
 | Resource       | Logic                                                                                                                                                 |
 |:---------------|:------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Databases**  | Creates databases listed in `database_names`. <br> *Fallback:* If the list is empty, creates a single database named after the instance (`var.name`). |
-| **Admin User** | Creates an admin user named `admin_user`. <br> *Fallback:* If not set, creates a user named after the instance (`var.name`).                          |
+| **Admin User** | Creates an admin user named `admin_spec.name`. <br> *Fallback:* If not set, creates a user named after the instance (`var.name`).                          |
 
 ## Usage Example
 
@@ -26,8 +26,8 @@ To minimize configuration for simple use cases, this module uses "Convention ove
   acls = ["cluster", "egress", "range"] # Ask the platform team for the correct egress range
 
   database_names = ["list-of-names", "to-create-databases"] # optional, will fallback to `var.name` if not present
-  admin_name = "root" # optional, will fallback to `var.name` if not present
-  user_names = ["additional", "user"] # optional
+  admin_spec = { name = "root" } # optional, will fallback to `var.name` if not present
+  user_spec_map = { lorem = { name = "lorem" }, ipsum = { name = "ipsum" } } # optional
 
   secret_manager_instance_id = "[your secrets manager instance id]"
   # available as output from stackit-secrets-manager module
@@ -109,7 +109,7 @@ When the variable is not set, the manifest will not be created.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acls"></a> [acls](#input\_acls) | List of ACL IDs to associate with the database instance. This should be the cluster Egress IP Range only! | `list(string)` | n/a | yes |
-| <a name="input_admin_name"></a> [admin\_name](#input\_admin\_name) | Specified the name of the Postgres Database Owner | `string` | `null` | no |
+| <a name="input_admin_spec"></a> [admin\_spec](#input\_admin\_spec) | Specified the name of the Postgres Database Owner and (optionally) a custom Secret Manager path. Example: { name = "admin", secret\_manager\_path = "custom/path/admin" }. If secret\_manager\_path is omitted, a default path is used. | <pre>object({<br/>    name                = string<br/>    secret_manager_path = optional(string)<br/>  })</pre> | <pre>{<br/>  "name": null<br/>}</pre> | no |
 | <a name="input_backup_schedule"></a> [backup\_schedule](#input\_backup\_schedule) | Backup schedule in cron format. Defaults to daily at 3am UTC. | `string` | `"0 3 * * *"` | no |
 | <a name="input_config_map_manifest"></a> [config\_map\_manifest](#input\_config\_map\_manifest) | Path where the config map manifest will be stored at | `string` | `null` | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | Specifies the CPU specs of the instance. Available Options: 2, 4, 8 & 16 | `number` | n/a | yes |
@@ -125,7 +125,7 @@ When the variable is not set, the manifest will not be created.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the STACKIT project where the database will be created. | `string` | n/a | yes |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of read replicas for the instance. | `number` | `1` | no |
 | <a name="input_secret_manager_instance_id"></a> [secret\_manager\_instance\_id](#input\_secret\_manager\_instance\_id) | Instance ID of the STACKIT Secret Manager, in which the database user password will be stored if manage\_user\_password is true. | `string` | `""` | no |
-| <a name="input_user_names"></a> [user\_names](#input\_user\_names) | List of additional database users to create. Elements must be unique. | `set(string)` | `[]` | no |
+| <a name="input_user_spec_map"></a> [user\_spec\_map](#input\_user\_spec\_map) | Map of additional database users to create. Elements must be unique. Example: { user1 = { name = "user1", secret\_manager\_path = "custom/path/user1" }, user2 = { name = "user2" } }. If secret\_manager\_path is omitted for a user, a default path is used. | <pre>map(object({<br/>    name                = string<br/>    secret_manager_path = optional(string)<br/>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/stackit-postgres-db/main.tf
+++ b/stackit-postgres-db/main.tf
@@ -1,9 +1,20 @@
 locals {
   # If database_names is empty, default to a set containing just the instance name.
   # Otherwise, use the provided set.
-  databases = length(var.database_names) == 0 ? toset([var.name]) : var.database_names
-  # Create the admin user with the name of the instance if not set explicitly
-  admin_user              = coalesce(var.admin_name, var.name)
+  databases      = length(var.database_names) == 0 ? toset([var.name]) : var.database_names
+  admin_username = coalesce(try(var.admin_spec.name, null), var.name)
+  admin_secret_path = coalesce(
+    try(trimspace(var.admin_spec.secret_manager_path), null),
+    "postgres/${local.admin_username}"
+  )
+  user_secret_paths = {
+    for k, u in var.user_spec_map :
+    k => coalesce(
+      try(trimspace(u.secret_manager_path), null),
+      "postgres/${u.name}"
+    )
+  }
+
   yaml_autocreate_warning = <<-EOT
     ###
     # DO NOT EDIT MANUALLY
@@ -33,7 +44,7 @@ resource "stackit_postgresflex_user" "admin" {
   project_id  = var.project_id
   instance_id = stackit_postgresflex_instance.this.instance_id
   roles       = ["login", "createdb"]
-  username    = local.admin_user
+  username    = local.admin_username
 }
 
 resource "stackit_postgresflex_database" "database" {
@@ -46,21 +57,20 @@ resource "stackit_postgresflex_database" "database" {
 }
 
 resource "stackit_postgresflex_user" "user" {
-  for_each = var.user_names # Simple set iteration
+  for_each = var.user_spec_map
 
   project_id  = var.project_id
   instance_id = stackit_postgresflex_instance.this.instance_id
   roles       = ["login"]
-  username    = each.key
+  username    = each.value.name
 }
-
 
 resource "vault_kv_secret_v2" "postgres_admin_credentials" {
   # Create only if enabled
   count = var.manage_user_password ? 1 : 0
 
   mount = var.secret_manager_instance_id
-  name  = "postgres/${stackit_postgresflex_user.admin.username}"
+  name  = local.admin_secret_path
 
   data_json = jsonencode({
     username = stackit_postgresflex_user.admin.username
@@ -70,11 +80,10 @@ resource "vault_kv_secret_v2" "postgres_admin_credentials" {
 }
 
 resource "vault_kv_secret_v2" "postgres_user_credentials" {
-  # Loop over users only if enabled
-  for_each = var.manage_user_password ? var.user_names : []
+  for_each = var.manage_user_password ? var.user_spec_map : {}
 
   mount = var.secret_manager_instance_id
-  name  = "postgres/${stackit_postgresflex_user.user[each.key].username}"
+  name  = local.user_secret_paths[each.key]
 
   data_json = jsonencode({
     username = stackit_postgresflex_user.user[each.key].username
@@ -113,23 +122,23 @@ resource "local_file" "external_secret_manifest" {
       data = concat(
         [
           {
-            secretKey = "${local.admin_user}_user"
-            remoteRef = { key = "postgres/${local.admin_user}", property = "username" }
+            secretKey = "${local.admin_username}_user"
+            remoteRef = { key = local.admin_secret_path, property = "username" }
           },
           {
-            secretKey = "${local.admin_user}_password"
-            remoteRef = { key = "postgres/${local.admin_user}", property = "password" }
+            secretKey = "${local.admin_username}_password"
+            remoteRef = { key = local.admin_secret_path, property = "password" }
           }
         ],
         flatten([
-          for user in var.user_names : [
+          for k, u in var.user_spec_map : [
             {
-              secretKey = "${user}_user"
-              remoteRef = { key = "postgres/${user}", property = "username" }
+              secretKey = "${u.name}_user"
+              remoteRef = { key = local.user_secret_paths[k], property = "username" }
             },
             {
-              secretKey = "${user}_password"
-              remoteRef = { key = "postgres/${user}", property = "password" }
+              secretKey = "${u.name}_password"
+              remoteRef = { key = local.user_secret_paths[k], property = "password" }
             }
           ]
         ])
@@ -147,6 +156,7 @@ resource "local_file" "config_map_manifest" {
       error_message = "You enabled 'config_map_manifest' but did not provide 'kubernetes_namespace'."
     }
   }
+
   filename = var.config_map_manifest
 
   content = format("%s%s", local.yaml_autocreate_warning, join("\n---\n", [

--- a/stackit-postgres-db/main.tf
+++ b/stackit-postgres-db/main.tf
@@ -2,13 +2,16 @@ locals {
   # If database_names is empty, default to a set containing just the instance name.
   # Otherwise, use the provided set.
   databases      = length(var.database_names) == 0 ? toset([var.name]) : var.database_names
-  admin_username = coalesce(try(var.admin_spec.name, null), var.name)
+  admin_username = coalesce(try(var.admin_user.name, null), var.name)
   admin_secret_path = coalesce(
-    try(trimspace(var.admin_spec.secret_manager_path), null),
+    try(trimspace(var.admin_user.secret_manager_path), null),
     "postgres/${local.admin_username}"
   )
+
+  additional_users_map = { for u in var.additional_users : u.name => u }
+
   user_secret_paths = {
-    for k, u in var.user_spec_map :
+    for k, u in local.additional_users_map :
     k => coalesce(
       try(trimspace(u.secret_manager_path), null),
       "postgres/${u.name}"
@@ -57,7 +60,7 @@ resource "stackit_postgresflex_database" "database" {
 }
 
 resource "stackit_postgresflex_user" "user" {
-  for_each = var.user_spec_map
+  for_each = local.additional_users_map
 
   project_id  = var.project_id
   instance_id = stackit_postgresflex_instance.this.instance_id
@@ -80,7 +83,7 @@ resource "vault_kv_secret_v2" "postgres_admin_credentials" {
 }
 
 resource "vault_kv_secret_v2" "postgres_user_credentials" {
-  for_each = var.manage_user_password ? var.user_spec_map : {}
+  for_each = var.manage_user_password ? local.additional_users_map : {}
 
   mount = var.secret_manager_instance_id
   name  = local.user_secret_paths[each.key]
@@ -131,7 +134,7 @@ resource "local_file" "external_secret_manifest" {
           }
         ],
         flatten([
-          for k, u in var.user_spec_map : [
+          for k, u in local.additional_users_map : [
             {
               secretKey = "${u.name}_user"
               remoteRef = { key = local.user_secret_paths[k], property = "username" }

--- a/stackit-postgres-db/outputs.tf
+++ b/stackit-postgres-db/outputs.tf
@@ -9,8 +9,8 @@ output "credentials" {
   value = merge(
     { (stackit_postgresflex_user.admin.username) = var.manage_user_password ? "" : stackit_postgresflex_user.admin.password },
     {
-      for user_key, user_spec in var.user_spec_map :
-      user_spec.name => var.manage_user_password ? "" : stackit_postgresflex_user.user[user_key].password
+      for name, user in local.additional_users_map :
+      name => var.manage_user_password ? "" : stackit_postgresflex_user.user[name].password
     }
   )
 }

--- a/stackit-postgres-db/outputs.tf
+++ b/stackit-postgres-db/outputs.tf
@@ -9,8 +9,8 @@ output "credentials" {
   value = merge(
     { (stackit_postgresflex_user.admin.username) = var.manage_user_password ? "" : stackit_postgresflex_user.admin.password },
     {
-      for user in var.user_names :
-      user => var.manage_user_password ? "" : stackit_postgresflex_user.user[user].password
+      for user_key, user_spec in var.user_spec_map :
+      user_spec.name => var.manage_user_password ? "" : stackit_postgresflex_user.user[user_key].password
     }
   )
 }

--- a/stackit-postgres-db/tests/postgres.tftest.hcl
+++ b/stackit-postgres-db/tests/postgres.tftest.hcl
@@ -96,7 +96,6 @@ run "multiple_databases" {
     manage_user_password = false
   }
 
-
   assert {
     condition     = stackit_postgresflex_database.database["foo"].owner == stackit_postgresflex_user.admin.username
     error_message = "The database owner should be the user created by this module"
@@ -110,8 +109,13 @@ run "multiple_databases" {
 
 run "multiple_users" {
   variables {
-    user_names           = ["lorem", "ipsum"]
-    admin_name           = "admin"
+    admin_spec = {
+      name = "admin"
+    }
+    user_spec_map = {
+      lorem = { name = "lorem" }
+      ipsum = { name = "ipsum" }
+    }
     manage_user_password = false
   }
 
@@ -122,7 +126,12 @@ run "multiple_users" {
 
   assert {
     condition     = stackit_postgresflex_user.user["lorem"].username == "lorem"
-    error_message = "Admin username should be 'lorem'"
+    error_message = "User username should be 'lorem'"
+  }
+
+  assert {
+    condition     = stackit_postgresflex_user.user["ipsum"].username == "ipsum"
+    error_message = "User username should be 'ipsum'"
   }
 }
 
@@ -131,15 +140,17 @@ run "secrets_and_manifest" {
 
   variables {
     name = "test-secrets"
-
-    user_names                 = ["lorem"]
-    admin_name                 = "root"
+    admin_spec = {
+      name = "root"
+    }
+    user_spec_map = {
+      lorem = { name = "lorem" }
+    }
     manage_user_password       = true
     secret_manager_instance_id = "mock-vault"
 
     external_secret_manifest = "output.yaml"
     kubernetes_namespace     = "namespace"
-
   }
 
   assert {
@@ -190,7 +201,7 @@ run "external_secret_manifest_missing" {
     external_secret_manifest = null
   }
 
-  # We want to mnanage the secrets externally but forgot to specify the K8s manifest file path to glue things together
+  # We want to manage the secrets externally but forgot to specify the K8s manifest file path to glue things together
   expect_failures = [
     local_file.external_secret_manifest
   ]
@@ -201,12 +212,16 @@ run "config_map_manifest" {
 
   variables {
     database_names = ["foo", "bar"]
-    user_names     = ["lorem", "ipsum"]
+    user_spec_map = {
+      lorem = { name = "lorem" }
+      ipsum = { name = "ipsum" }
+    }
 
     manage_user_password = false
     config_map_manifest  = "config.yaml"
     kubernetes_namespace = "namespace"
   }
+
   assert {
     condition     = yamldecode(split("\n---\n", local_file.config_map_manifest[0].content)[0]).metadata.name == "database-config-bar"
     error_message = "First ConfigMap should be for 'bar'"
@@ -229,10 +244,44 @@ run "kubernetes_namespace_missing" {
     kubernetes_namespace     = null
   }
 
-  # We want to mnanage the secrets externally but forgot to specify the K8s manifest file path to glue things together
+  # We want to manage the secrets externally but forgot to specify the K8s manifest file path to glue things together
   expect_failures = [
     local_file.external_secret_manifest,
     local_file.config_map_manifest
   ]
 }
 
+run "custom_secret_manager_paths" {
+  command = apply
+
+  variables {
+    name = "test-custom-paths"
+
+    manage_user_password       = true
+    secret_manager_instance_id = "mock-vault"
+
+    kubernetes_namespace     = "namespace"
+    external_secret_manifest = "custom-paths.yaml"
+
+    admin_spec = {
+      name                = "root"
+      secret_manager_path = "custom/root-admin"
+    }
+    user_spec_map = {
+      lorem = {
+        name                = "lorem"
+        secret_manager_path = "custom/lorem-user"
+      }
+    }
+  }
+
+  assert {
+    condition     = contains(output.secret_manager_secret_names, "custom/root-admin")
+    error_message = "Secret names list should contain the custom admin secret_manager_path"
+  }
+
+  assert {
+    condition     = contains(output.secret_manager_secret_names, "custom/lorem-user")
+    error_message = "Secret names list should contain the custom user secret_manager_path"
+  }
+}

--- a/stackit-postgres-db/tests/postgres.tftest.hcl
+++ b/stackit-postgres-db/tests/postgres.tftest.hcl
@@ -109,13 +109,13 @@ run "multiple_databases" {
 
 run "multiple_users" {
   variables {
-    admin_spec = {
+    admin_user = {
       name = "admin"
     }
-    user_spec_map = {
-      lorem = { name = "lorem" }
-      ipsum = { name = "ipsum" }
-    }
+    additional_users = [
+      { name = "lorem" },
+      { name = "ipsum" }
+    ]
     manage_user_password = false
   }
 
@@ -140,12 +140,12 @@ run "secrets_and_manifest" {
 
   variables {
     name = "test-secrets"
-    admin_spec = {
+    admin_user = {
       name = "root"
     }
-    user_spec_map = {
-      lorem = { name = "lorem" }
-    }
+    additional_users = [
+      { name = "lorem" }
+    ]
     manage_user_password       = true
     secret_manager_instance_id = "mock-vault"
 
@@ -212,10 +212,10 @@ run "config_map_manifest" {
 
   variables {
     database_names = ["foo", "bar"]
-    user_spec_map = {
-      lorem = { name = "lorem" }
-      ipsum = { name = "ipsum" }
-    }
+    additional_users = [
+      { name = "lorem" },
+      { name = "ipsum" }
+    ]
 
     manage_user_password = false
     config_map_manifest  = "config.yaml"
@@ -263,16 +263,16 @@ run "custom_secret_manager_paths" {
     kubernetes_namespace     = "namespace"
     external_secret_manifest = "custom-paths.yaml"
 
-    admin_spec = {
+    admin_user = {
       name                = "root"
       secret_manager_path = "custom/root-admin"
     }
-    user_spec_map = {
-      lorem = {
+    additional_users = [
+      {
         name                = "lorem"
         secret_manager_path = "custom/lorem-user"
       }
-    }
+    ]
   }
 
   assert {

--- a/stackit-postgres-db/variables.tf
+++ b/stackit-postgres-db/variables.tf
@@ -3,10 +3,13 @@ variable "name" {
   type        = string
 }
 
-variable "admin_name" {
-  description = "Specified the name of the Postgres Database Owner"
-  type        = string
-  default     = null
+variable "admin_spec" {
+  description = "Specified the name of the Postgres Database Owner and (optionally) a custom Secret Manager path. Example: { name = \"admin\", secret_manager_path = \"custom/path/admin\" }. If secret_manager_path is omitted, a default path is used."
+  type = object({
+    name                = string
+    secret_manager_path = optional(string)
+  })
+  default = { name = null }
 }
 
 variable "database_names" {
@@ -15,10 +18,13 @@ variable "database_names" {
   default     = []
 }
 
-variable "user_names" {
-  description = "List of additional database users to create. Elements must be unique."
-  type        = set(string)
-  default     = []
+variable "user_spec_map" {
+  description = "Map of additional database users to create. Elements must be unique. Example: { user1 = { name = \"user1\", secret_manager_path = \"custom/path/user1\" }, user2 = { name = \"user2\" } }. If secret_manager_path is omitted for a user, a default path is used."
+  type = map(object({
+    name                = string
+    secret_manager_path = optional(string)
+  }))
+  default = {}
 }
 
 variable "project_id" {

--- a/stackit-postgres-db/variables.tf
+++ b/stackit-postgres-db/variables.tf
@@ -3,8 +3,8 @@ variable "name" {
   type        = string
 }
 
-variable "admin_spec" {
-  description = "Specified the name of the Postgres Database Owner and (optionally) a custom Secret Manager path. Example: { name = \"admin\", secret_manager_path = \"custom/path/admin\" }. If secret_manager_path is omitted, a default path is used."
+variable "admin_user" {
+  description = "Specified the name of the Postgres Database Owner and (optionally) a custom Secret Manager path. Example: { name = \"admin\", secret_manager_path = \"custom/path/admin\" }. If secret_manager_path is omitted, a default path is used. If admin_user is not specified, a user with the same name as the instance will be created."
   type = object({
     name                = string
     secret_manager_path = optional(string)
@@ -18,13 +18,13 @@ variable "database_names" {
   default     = []
 }
 
-variable "user_spec_map" {
-  description = "Map of additional database users to create. Elements must be unique. Example: { user1 = { name = \"user1\", secret_manager_path = \"custom/path/user1\" }, user2 = { name = \"user2\" } }. If secret_manager_path is omitted for a user, a default path is used."
-  type = map(object({
+variable "additional_users" {
+  description = "List of additional database users to create. Names must be unique. Example: [{ name = \"user1\", secret_manager_path = \"custom/path/user1\" }, { name = \"user2\" }]. If secret_manager_path is omitted for a user, a default path is used."
+  type = list(object({
     name                = string
     secret_manager_path = optional(string)
   }))
-  default = {}
+  default = []
 }
 
 variable "project_id" {


### PR DESCRIPTION
- `admin_name` is now `admin_user`, an object with `{ name = "[name]", secret_manager_path = "[custom/path]" }`
- `user_names` is now `additional_users`, a list like `[{ name = "user1", secret_manager_path = "custom/path/user1" }, { name = "user2" }]`