### PR TITLE
feat(secrets-manager): encode password in base64 for external secrets PL-20

### DIFF
--- a/stackit-secrets-manager/outputs.tf
+++ b/stackit-secrets-manager/outputs.tf
@@ -67,8 +67,8 @@ output "external_secrets_secret_manifest" {
         namespace = var.kubernetes_namespace
       }
       type = "Opaque"
-      stringData = {
-        password = stackit_secretsmanager_user.external_secrets.password
+      data = {
+        password = base64encode(stackit_secretsmanager_user.external_secrets.password)
       }
     })
   )

--- a/stackit-secrets-manager/tests/secrets_manager.tftest.hcl
+++ b/stackit-secrets-manager/tests/secrets_manager.tftest.hcl
@@ -76,12 +76,12 @@ EOT
     condition     = nonsensitive(output.external_secrets_secret_manifest) == <<EOT
 # DO NOT COMMIT THIS! USE KUBESEAL TO CREATE A SEALED SECRET INSTEAD
 "apiVersion": "v1"
+"data":
+  "password": "cGFzc3dvcmQ="
 "kind": "Secret"
 "metadata":
   "name": "secrets-manager-password"
   "namespace": "platform"
-"stringData":
-  "password": "password"
 "type": "Opaque"
 EOT
     error_message = "External Secrets Secret manifest is incorrect"


### PR DESCRIPTION
Encoding with base64 as data instead of stringData makes sure that special characters can't mess up the manifest.