### PR TITLE
feat(stackit-object-storage): add additional_policy_jsons

### DIFF
--- a/stackit-object-storage/README.md
+++ b/stackit-object-storage/README.md
@@ -15,9 +15,29 @@ By default, two credentials are created:
 
 The module is also creating polices that restrict access to the bucket only to the created credentials (and the
 credentials group identified by `terraform_credentials_group_id` to manage the bucket). If you want to create your own
-policies (e.g. in case you need public access), you can disable this behavior by setting the `enable_policy_creation`
+policies, you can disable this behavior by setting the `enable_policy_creation`
 input variable to `false`. Please note that in this case all credentials in the same STACKIT project will have access to
 your bucket.
+
+You may add any additional policies to `additional_policy_jsons`, for example to allow for public read access:
+
+```hcl
+data "aws_iam_policy_document" "public_read" {
+  statement {
+    sid       = "PublicRead"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::your-bucket-name/*"]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
+module "my_bucket" {
+  additional_policy_jsons = [data.aws_iam_policy_document.public_read.json] 
+}
+```
 
 > ⚠️ Bucket names need to be unique per STACKIT region. It is recommended to prefix the bucket name with `ds-` and your
 > project name to avoid name collisions.
@@ -158,6 +178,7 @@ module "object_storage_bucket" {
 | <a name="input_credentials"></a> [credentials](#input\_credentials) | Bucket credentials to create. Map of credential name to an object with the credential's role and (optionally) a custom Secret Manager path. Example: { admin = { role = "superuser", secret\_manager\_path = "object-storage/bucket-name/admin" } }. If secret\_manager\_path is omitted, a default path is used. | <pre>map(object({<br/>    role                = string<br/>    secret_manager_path = optional(string)<br/>  }))</pre> | <pre>{<br/>  "default": {<br/>    "role": "superuser"<br/>  }<br/>}</pre> | no |
 | <a name="input_enable_manifest_creation"></a> [enable\_manifest\_creation](#input\_enable\_manifest\_creation) | Set to true to create an External Secret manifest for Kubernetes to access the created credentials. | `bool` | `true` | no |
 | <a name="input_enable_policy_creation"></a> [enable\_policy\_creation](#input\_enable\_policy\_creation) | Set to false in case you want to create your own policy. WARNING: If you disable this, all credentials in the same STACKIT project have access to your bucket. | `bool` | `true` | no |
+| <a name="additional_policy_jsons"></a> [additional\_policy\_jsons](#additional\_policy\_jsons) | Pass a set of additional json-encoded `aws_iam_policy_document` to be applied. | `list(string)` | `[]` | no |
 | <a name="input_external_secret_manifest"></a> [external\_secret\_manifest](#input\_external\_secret\_manifest) | Path where the external secret manifest will be stored at | `string` | `null` | no |
 | <a name="input_kubernetes_namespace"></a> [kubernetes\_namespace](#input\_kubernetes\_namespace) | Kubernetes namespace where the External Secret manifest will be applied. | `string` | `null` | no |
 | <a name="input_manage_credentials"></a> [manage\_credentials](#input\_manage\_credentials) | Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]` | `bool` | `false` | no |

--- a/stackit-object-storage/policies.tf
+++ b/stackit-object-storage/policies.tf
@@ -15,6 +15,7 @@ data "aws_iam_policy_document" "combined_policy" {
     contains(local.roles_used, "read-only") ? data.aws_iam_policy_document.read_only[0].json : "",
     contains(local.roles_used, "read-write") ? data.aws_iam_policy_document.read_write[0].json : "",
   ]
+  override_policy_documents = var.additional_policy_jsons
 }
 
 data "aws_iam_policy_document" "disable_access_for_other_credentials_groups" {

--- a/stackit-object-storage/tests/policies.tftest.hcl
+++ b/stackit-object-storage/tests/policies.tftest.hcl
@@ -122,7 +122,7 @@ run "policy_generation" {
 }
 
 
-run "exsting_terraform_credential_group" {
+run "existing_terraform_credential_group" {
   command = apply
 
   variables {
@@ -147,5 +147,40 @@ run "exsting_terraform_credential_group" {
       jsondecode(data.aws_iam_policy_document.combined_policy.json).Statement[0].NotPrincipal.AWS == ["urn:stackit:objectstorage:credentialsgroup:ro", "urn:stackit:objectstorage:credentialsgroup:existing_tf_group"]
     )
     error_message = "Policy to restrict access for other credentials groups is incorrect"
+  }
+}
+
+run "merged_policy_with_public_read" {
+  command = apply
+
+  variables {
+    bucket_name                    = "test-bucket-public"
+    terraform_credentials_group_id = "12168432-2b8f-44de-8514-11bd9f9ad8b6"
+    additional_policy_jsons = [
+      jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Sid       = "TestPublicRead"
+            Effect    = "Allow"
+            Principal = "*"
+            Action    = ["s3:GetObject"]
+            Resource  = ["arn:aws:s3:::test-bucket-public/*"]
+          }
+        ]
+      })
+    ]
+  }
+
+  # Assert that the policy now has 2 statements (Default + Public Read)
+  assert {
+    condition     = length(jsondecode(aws_s3_bucket_policy.bucket_policy[0].policy).Statement) == 2
+    error_message = "Expected exactly 2 statements after merging, but found a different amount."
+  }
+
+  # Assert that the specific Public Read rule actually made it into the final JSON string
+  assert {
+    condition     = strcontains(aws_s3_bucket_policy.bucket_policy[0].policy, "TestPublicRead")
+    error_message = "The merged policy did not contain the expected 'TestPublicRead' Sid."
   }
 }

--- a/stackit-object-storage/variables.tf
+++ b/stackit-object-storage/variables.tf
@@ -45,6 +45,12 @@ variable "enable_policy_creation" {
   default     = true
 }
 
+variable "additional_policy_jsons" {
+  description = "A list of additional IAM policy documents (in JSON format) to merge with the module's default bucket policy."
+  type        = list(string)
+  default     = []
+}
+
 variable "manage_credentials" {
   description = "Set true to add the credentials into the STACKIT Secrets Manager. The credentials will be at `object-storage/[bucket name]/[credential name]`"
   type        = bool


### PR DESCRIPTION
Note: We need public read access but do not want to re-write all policies and users - hopefully a more modular way to extend the existing policy

(note: we still need to verify this is actually doing what we expect)